### PR TITLE
Fix neighborhood factors edge case when seq_init=True and cross_view=True

### DIFF
--- a/vipe/slam/components/factor_graph.py
+++ b/vipe/slam/components/factor_graph.py
@@ -403,7 +403,7 @@ class FactorGraph:
         ii = ii.reshape(-1).to(dtype=torch.long, device=self.device)
         jj = jj.reshape(-1).to(dtype=torch.long, device=self.device)
 
-        c = 1 if self.cross_view else 0
+        c = -1 if self.cross_view else 0
 
         keep = ((ii - jj).abs() > c) & ((ii - jj).abs() <= r)
         self.add_factors(ii[keep], jj[keep])


### PR DESCRIPTION
Fixes #11

### Problem
When both `seq_init=True` and `cross_view=True` are enabled, the filtering condition becomes mathematically impossible to satisfy:
- `seq_init=True` sets `r=1`
- `cross_view=True` sets `c=1` 
- Condition: `abs(ii-jj) > 1 AND abs(ii-jj) <= 1` is impossible

This results in zero edges being added to the factor graph, causing initialization to fail.

### Solution
Changed `c = 1 if self.cross_view else 0` to `c = -1 if self.cross_view else 0`

This allows:
- Cross-view connections at same timestamp (`ii == jj`)
- Neighborhood connections within radius `r`

### Testing
- [X] Previously failing 360-degree video now processes successfully
- [X] No regression on existing functionality

### Credit
Thanks to @heiwang1997 for the elegant solution suggestion!