### PR TITLE
fix: replace 7 bare excepts with except Exception across 5 files

### DIFF
--- a/vipe/priors/depth/metric3d/model/backbones/ViT_DINO_reg.py
+++ b/vipe/priors/depth/metric3d/model/backbones/ViT_DINO_reg.py
@@ -1155,14 +1155,14 @@ def load_ckpt_dino(checkpoint, model):
         try:
             with open(checkpoint, "rb") as f:
                 state_dict = torch.load(f)
-        except:
+        except Exception:
             print("NO pretrained imagenet ckpt available! Check your path!")
             del model.mask_token
             return
 
         try:
             model.load_state_dict(state_dict, strict=True)
-        except:
+        except Exception:
             new_state_dict = {}
             for key, value in state_dict.items():
                 if "blocks" in key:
@@ -1226,7 +1226,7 @@ def vit_large(patch_size=14, num_register_tokens=0, checkpoint=None, **kwargs):
             state_dict = torch.load(f)
         try:
             model.load_state_dict(state_dict, strict=True)
-        except:
+        except Exception:
             new_state_dict = {}
             for key, value in state_dict.items():
                 if "blocks" in key:
@@ -1338,7 +1338,7 @@ def vit_giant2_reg(patch_size=14, num_register_tokens=4, checkpoint=None, tuning
 if __name__ == "__main__":
     try:
         from mmcv.utils import Config
-    except:
+    except Exception:
         from mmengine import Config
 
     # rgb = torch.rand((2, 3, 518, 518)).cuda()

--- a/vipe/priors/depth/metric3d/model/decode_heads/RAFTDepthNormalDPTDecoder5.py
+++ b/vipe/priors/depth/metric3d/model/decode_heads/RAFTDepthNormalDPTDecoder5.py
@@ -1012,7 +1012,7 @@ class RAFTDepthNormalDPT5(nn.Module):
         self.regress_scale = 100.0
         try:
             tuning_mode = cfg.model.decode_head.tuning_mode
-        except:
+        except Exception:
             tuning_mode = None
         self.tuning_mode = tuning_mode
 

--- a/vipe/priors/depth/metric3d/model/dense_pipeline.py
+++ b/vipe/priors/depth/metric3d/model/dense_pipeline.py
@@ -26,7 +26,7 @@ def get_func(func_name):
         module_name = ".".join(parts[:-1])
         module = importlib.import_module(module_name)
         return getattr(module, parts[-1])
-    except:
+    except Exception:
         raise RuntimeError(f"Failed to find function: {func_name}")
 
 

--- a/vipe/priors/track_anything/aot/utils/checkpoint.py
+++ b/vipe/priors/track_anything/aot/utils/checkpoint.py
@@ -113,7 +113,7 @@ def save_network(net, opt, step, save_path, max_keep=8, backup_dir="./saved_mode
         save_file = "save_step_%s.pth" % (step)
         save_dir = os.path.join(save_path, save_file)
         torch.save(ckpt, save_dir)
-    except:
+    except Exception:
         save_path = backup_dir
         if not os.path.exists(save_path):
             os.makedirs(save_path)

--- a/vipe/priors/track_anything/groundingdino/util/box_ops.py
+++ b/vipe/priors/track_anything/groundingdino/util/box_ops.py
@@ -49,7 +49,7 @@ def generalized_box_iou(boxes1, boxes2):
     # so do an early check
     assert (boxes1[:, 2:] >= boxes1[:, :2]).all()
     assert (boxes2[:, 2:] >= boxes2[:, :2]).all()
-    # except:
+    # except Exception:
     #     import ipdb; ipdb.set_trace()
     iou, union = box_iou(boxes1, boxes2)
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in 5 files (7 sites). Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`.