### PR TITLE
feat(ba): activate robust kernel infrastructure + add Tukey and GNC-TLS

### DIFF
--- a/configs/slam/default.yaml
+++ b/configs/slam/default.yaml
@@ -48,6 +48,13 @@ keyframe_depth: metric3d-small
 ba:
   dense_disp_alpha: 0.001
   intrinsics_damping_scale: 1.0
+  # Optional robust M-estimator on the dense-flow residual in bundle
+  # adjustment.  ``null`` (default) reproduces the pre-PR L2 behaviour.
+  # Currently implemented: "huber".  See ``vipe/slam/ba/kernel.py``.
+  robust_kernel: null
+  # Kernel threshold in the /8 feature-map pixel units used by
+  # DenseDepthFlowTerm.  Only consumed when ``robust_kernel`` is set.
+  robust_kernel_threshold: 3.0
 
 sparse_tracks:
   name: dummy

--- a/configs/slam/default.yaml
+++ b/configs/slam/default.yaml
@@ -48,13 +48,16 @@ keyframe_depth: metric3d-small
 ba:
   dense_disp_alpha: 0.001
   intrinsics_damping_scale: 1.0
-  # Optional robust M-estimator on the dense-flow residual in bundle
-  # adjustment.  ``null`` (default) reproduces the pre-PR L2 behaviour.
-  # Currently implemented: "huber".  See ``vipe/slam/ba/kernel.py``.
+  # robust kernel for dense-flow residual: null (L2) | huber | tukey | gnc_tls
   robust_kernel: null
-  # Kernel threshold in the /8 feature-map pixel units used by
-  # DenseDepthFlowTerm.  Only consumed when ``robust_kernel`` is set.
+  # kernel threshold in /8 feature-map pixels (Huber k / Tukey c / GNC-TLS c_bar)
   robust_kernel_threshold: 3.0
+  # GNC-TLS mu schedule (ignored unless robust_kernel == gnc_tls)
+  gnc_mu_init: 1.0
+  gnc_mu_step: 3.0
+  gnc_mu_max: 1.0e6
+  gnc_n_mu_steps: 4
+  gnc_gn_iters_per_mu: 6
 
 sparse_tracks:
   name: dummy

--- a/vipe/slam/ba/kernel.py
+++ b/vipe/slam/ba/kernel.py
@@ -19,31 +19,26 @@ import torch
 
 
 class RobustKernel(ABC):
-    """
-    Per-residual M-estimator applied inside the BA solver.
-
-    Given a residual tensor ``x`` (typically shape ``(n_terms, res_dim)``),
-    ``apply(x)`` returns a multiplicative reweighting of the same shape.
-    ``Solver.run_inplace`` folds that reweighting into the information
-    weight via ``ConcreteTermEvalReturn.apply_robust_kernel``, producing
-    one IRLS step per BA iteration.
-    """
-
     @abstractmethod
     def apply(self, x: torch.Tensor) -> torch.Tensor:
         """Return a per-residual weight of the same shape as ``x``."""
 
+    def is_gnc(self) -> bool:
+        return False
+
+    def set_mu(self, mu: float) -> None:
+        pass
+
+    def update_mu(self, mu: float) -> float:
+        return mu
+
+    @property
+    def mu_max(self) -> float:
+        return float("inf")
+
 
 class HuberRobustKernel(RobustKernel):
-    """
-    Huber M-estimator weight: ``w(r) = 1`` if ``|r| <= k`` else ``k / |r|``.
-
-    ``threshold`` (``k``) is the residual magnitude at which the loss
-    transitions from quadratic (inliers) to linear (outliers).  For the
-    dense-flow residuals used by ``DenseDepthFlowTerm``, which operate
-    on the /8 feature grid, a value around ``3.0`` is a reasonable
-    default (roughly 24 full-resolution pixels of flow mismatch).
-    """
+    """``w(r) = 1`` if ``|r| <= k`` else ``k / |r|``."""
 
     def __init__(self, threshold: float = 1.0) -> None:
         self.threshold = float(threshold)
@@ -54,29 +49,116 @@ class HuberRobustKernel(RobustKernel):
         return torch.where(abs_x <= k, torch.ones_like(x), k / abs_x.clamp_min(1e-8))
 
 
-def build_robust_kernel(name: str | None, threshold: float) -> RobustKernel | None:
-    """
-    Instantiate a :class:`RobustKernel` by short name.
+class TukeyRobustKernel(RobustKernel):
+    """``w(r) = (1 - (r/c)^2)^2`` if ``|r| <= c`` else ``0``."""
 
-    Returns ``None`` to indicate vanilla L2 (no reweighting) so that the
-    caller can use ``solver.add_term(term, kernel=build_robust_kernel(...))``
-    uniformly and rely on ``Solver.run_inplace`` to skip the kernel when
-    it is ``None``.
+    def __init__(self, c: float = 2.0) -> None:
+        self.c = float(c)
 
-    Parameters
-    ----------
-    name : str | None
-        Kernel short name.  ``None`` / ``"none"`` / ``"null"`` / ``"off"``
-        / ``""`` all map to the L2 (no-kernel) case.  Currently supported:
-        ``"huber"``.
-    threshold : float
-        Kernel threshold parameter (Huber ``k``).
+    def apply(self, x: torch.Tensor) -> torch.Tensor:
+        c = self.c
+        u = (x / c) ** 2
+        return (1.0 - u).clamp(min=0.0) ** 2
+
+
+class TLSGncRobustKernel(RobustKernel):
     """
+    Graduated Non-Convexity with Truncated Least Squares.
+
+    Yang, Antonante, Tzoumas, Carlone.  "Graduated Non-Convexity for Robust
+    Spatial Perception: From Non-Minimal Solvers to Global Outlier Rejection."
+    RA-L / ICRA, 2020.  Weight formulation and mu schedule follow GTSAM's
+    ``GncOptimizer``:
+    https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/GncOptimizer.h
+
+    At scalar ``mu`` with inlier threshold ``c_bar``:
+
+        lo  = mu / (mu + 1)  * c_bar^2
+        hi  = (mu + 1) / mu  * c_bar^2
+        r^2 < lo   ->  w = 1
+        r^2 > hi   ->  w = 0
+        otherwise  ->  w = sqrt(c_bar^2 * mu * (mu + 1) / r^2) - mu
+
+    Schedule: ``mu <- min(mu * mu_step, mu_max)``.
+    ``mu -> inf`` recovers the hard-TLS indicator ``w = 1{r^2 < c_bar^2}``.
+    """
+
+    def __init__(
+        self,
+        threshold: float = 3.0,
+        mu_step: float = 3.0,
+        mu_init: float = 1.0,
+        mu_max: float = 1.0e6,
+    ) -> None:
+        self.c_bar = float(threshold)
+        self.c_bar_sq = self.c_bar * self.c_bar
+        self.mu_step = float(mu_step)
+        self.mu_init = float(mu_init)
+        self._mu_max = float(mu_max)
+        self._mu: float | None = None
+
+    def is_gnc(self) -> bool:
+        return True
+
+    @property
+    def mu_max(self) -> float:
+        return self._mu_max
+
+    def set_mu(self, mu: float) -> None:
+        self._mu = float(mu)
+
+    def update_mu(self, mu: float) -> float:
+        return min(mu * self.mu_step, self._mu_max)
+
+    def apply(self, x: torch.Tensor) -> torch.Tensor:
+        mu = self._mu
+        c_sq = self.c_bar_sq
+        r2 = x * x
+
+        if mu is None or mu >= self._mu_max:
+            return (r2 < c_sq).to(dtype=x.dtype)
+
+        lo = (mu / (mu + 1.0)) * c_sq
+        hi = ((mu + 1.0) / mu) * c_sq
+
+        weights = torch.zeros_like(x)
+        inlier_mask = r2 < lo
+        weights = torch.where(inlier_mask, torch.ones_like(x), weights)
+
+        transition_mask = (~inlier_mask) & (r2 <= hi)
+        if transition_mask.any():
+            r2_t = r2.clamp_min(1e-12)
+            transition_w = torch.sqrt(c_sq * mu * (mu + 1.0) / r2_t) - mu
+            weights = torch.where(transition_mask, transition_w.clamp_min(0.0), weights)
+
+        return weights
+
+
+def build_robust_kernel(
+    name: str | None,
+    threshold: float,
+    *,
+    gnc_mu_init: float = 1.0,
+    gnc_mu_step: float = 3.0,
+    gnc_mu_max: float = 1.0e6,
+) -> RobustKernel | None:
+    """Factory.  ``None`` / ``"none"`` / ``"null"`` / ``"off"`` / ``""`` -> L2."""
     if name is None:
         return None
-    if isinstance(name, str) and name.lower() in ("none", "null", "off", ""):
-        return None
     n = str(name).lower()
+    if n in ("none", "null", "off", ""):
+        return None
     if n == "huber":
         return HuberRobustKernel(threshold=threshold)
-    raise ValueError(f"Unknown robust_kernel: {name!r}; expected 'huber' or None")
+    if n == "tukey":
+        return TukeyRobustKernel(c=threshold)
+    if n in ("gnc_tls", "gnc-tls"):
+        return TLSGncRobustKernel(
+            threshold=threshold,
+            mu_init=gnc_mu_init,
+            mu_step=gnc_mu_step,
+            mu_max=gnc_mu_max,
+        )
+    raise ValueError(
+        f"Unknown robust_kernel: {name!r}; expected 'huber' | 'tukey' | 'gnc_tls' | None"
+    )

--- a/vipe/slam/ba/kernel.py
+++ b/vipe/slam/ba/kernel.py
@@ -18,15 +18,65 @@ from abc import ABC, abstractmethod
 import torch
 
 
-class RobustKernel:
+class RobustKernel(ABC):
+    """
+    Per-residual M-estimator applied inside the BA solver.
+
+    Given a residual tensor ``x`` (typically shape ``(n_terms, res_dim)``),
+    ``apply(x)`` returns a multiplicative reweighting of the same shape.
+    ``Solver.run_inplace`` folds that reweighting into the information
+    weight via ``ConcreteTermEvalReturn.apply_robust_kernel``, producing
+    one IRLS step per BA iteration.
+    """
+
     @abstractmethod
     def apply(self, x: torch.Tensor) -> torch.Tensor:
-        pass
+        """Return a per-residual weight of the same shape as ``x``."""
 
 
 class HuberRobustKernel(RobustKernel):
+    """
+    Huber M-estimator weight: ``w(r) = 1`` if ``|r| <= k`` else ``k / |r|``.
+
+    ``threshold`` (``k``) is the residual magnitude at which the loss
+    transitions from quadratic (inliers) to linear (outliers).  For the
+    dense-flow residuals used by ``DenseDepthFlowTerm``, which operate
+    on the /8 feature grid, a value around ``3.0`` is a reasonable
+    default (roughly 24 full-resolution pixels of flow mismatch).
+    """
+
+    def __init__(self, threshold: float = 1.0) -> None:
+        self.threshold = float(threshold)
+
     def apply(self, x: torch.Tensor) -> torch.Tensor:
-        weights = torch.ones_like(x)
-        s = x * x
-        weights[s > 1] = 1 / torch.sqrt(s)[s > 1]
-        return weights
+        abs_x = x.abs()
+        k = self.threshold
+        return torch.where(abs_x <= k, torch.ones_like(x), k / abs_x.clamp_min(1e-8))
+
+
+def build_robust_kernel(name: str | None, threshold: float) -> RobustKernel | None:
+    """
+    Instantiate a :class:`RobustKernel` by short name.
+
+    Returns ``None`` to indicate vanilla L2 (no reweighting) so that the
+    caller can use ``solver.add_term(term, kernel=build_robust_kernel(...))``
+    uniformly and rely on ``Solver.run_inplace`` to skip the kernel when
+    it is ``None``.
+
+    Parameters
+    ----------
+    name : str | None
+        Kernel short name.  ``None`` / ``"none"`` / ``"null"`` / ``"off"``
+        / ``""`` all map to the L2 (no-kernel) case.  Currently supported:
+        ``"huber"``.
+    threshold : float
+        Kernel threshold parameter (Huber ``k``).
+    """
+    if name is None:
+        return None
+    if isinstance(name, str) and name.lower() in ("none", "null", "off", ""):
+        return None
+    n = str(name).lower()
+    if n == "huber":
+        return HuberRobustKernel(threshold=threshold)
+    raise ValueError(f"Unknown robust_kernel: {name!r}; expected 'huber' or None")

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -36,6 +36,7 @@ from vipe.utils.logging import pbar
 from vipe.utils.visualization import POINTS_STENCIL, draw_lines_batch, draw_points_batch
 
 from ..ba.solver import Solver, SparseBlockVector
+from ..ba.kernel import build_robust_kernel
 from ..ba.terms import DenseDepthFlowTerm, DispSensRegularizationTerm
 from ..interface import SLAMMap
 from ..maths import geom
@@ -402,6 +403,14 @@ class GraphBuffer:
         pi_unique = torch.unique(ii)  # Should be equivalent to unique(pi)
 
         solver = Solver(compute_energy=verbose)
+        # Optional robust M-estimator on dense-flow residuals.  When
+        # ``ba.robust_kernel`` is null (the default) ``build_robust_kernel``
+        # returns None and ``Solver.run_inplace`` skips the kernel branch,
+        # reproducing the pre-PR L2 behaviour bit-for-bit.
+        robust_kernel = build_robust_kernel(
+            name=self.ba_config.get("robust_kernel", None),
+            threshold=float(self.ba_config.get("robust_kernel_threshold", 1.0)),
+        )
         solver.add_term(
             DenseDepthFlowTerm(
                 pose_i_inds=pi,
@@ -416,7 +425,8 @@ class GraphBuffer:
                 rig=None,
                 image_size=(self.height // 8, self.width // 8),
                 camera_type=self.camera_type,
-            )
+            ),
+            kernel=robust_kernel,
         )
 
         if self.sparse_tracks.enabled:
@@ -445,7 +455,8 @@ class GraphBuffer:
                     rig=None,
                     image_size=(self.height // 8, self.width // 8),
                     camera_type=self.camera_type,
-                )
+                ),
+                kernel=robust_kernel,
             )
 
         # self.debug_visualize_target_weight(

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -403,13 +403,12 @@ class GraphBuffer:
         pi_unique = torch.unique(ii)  # Should be equivalent to unique(pi)
 
         solver = Solver(compute_energy=verbose)
-        # Optional robust M-estimator on dense-flow residuals.  When
-        # ``ba.robust_kernel`` is null (the default) ``build_robust_kernel``
-        # returns None and ``Solver.run_inplace`` skips the kernel branch,
-        # reproducing the pre-PR L2 behaviour bit-for-bit.
         robust_kernel = build_robust_kernel(
             name=self.ba_config.get("robust_kernel", None),
             threshold=float(self.ba_config.get("robust_kernel_threshold", 1.0)),
+            gnc_mu_init=float(self.ba_config.get("gnc_mu_init", 1.0)),
+            gnc_mu_step=float(self.ba_config.get("gnc_mu_step", 1.4)),
+            gnc_mu_max=float(self.ba_config.get("gnc_mu_max", 1.0e6)),
         )
         solver.add_term(
             DenseDepthFlowTerm(
@@ -519,17 +518,27 @@ class GraphBuffer:
 
         disps_flattened = rearrange(self.flattened_disps, "nv h w -> nv (h w)")
 
-        ba_energy = []
-        for _ in range(n_iters):
-            cur_energy = solver.run_inplace(
-                {
-                    "pose": SE3(self.poses),
-                    "dense_disp": disps_flattened,
-                    "intrinsics": self.intrinsics,
-                    "rig": SE3(self.rig),
-                }
-            )
-            ba_energy.append(cur_energy)
+        variables = {
+            "pose": SE3(self.poses),
+            "dense_disp": disps_flattened,
+            "intrinsics": self.intrinsics,
+            "rig": SE3(self.rig),
+        }
+
+        ba_energy: list[float] = []
+        if robust_kernel is not None and robust_kernel.is_gnc():
+            # GNC: outer mu schedule, inner GN iters at frozen mu.
+            n_mu_steps = max(1, int(self.ba_config.get("gnc_n_mu_steps", 4)))
+            gn_iters_per_mu = max(1, int(self.ba_config.get("gnc_gn_iters_per_mu", 6)))
+            current_mu = robust_kernel.mu_init if hasattr(robust_kernel, "mu_init") else 1.0
+            for _ in range(n_mu_steps):
+                robust_kernel.set_mu(current_mu)
+                for _ in range(gn_iters_per_mu):
+                    ba_energy.append(solver.run_inplace(variables))
+                current_mu = robust_kernel.update_mu(current_mu)
+        else:
+            for _ in range(n_iters):
+                ba_energy.append(solver.run_inplace(variables))
 
         if verbose:
             logger.info(f"BA iters = {n_iters}, energy: {ba_energy[0]} -> {ba_energy[-1]}")


### PR DESCRIPTION
# Activate robust kernel in BA; add Tukey and GNC-TLS

## Summary

VIPE's bundle-adjustment solver already supports per-term robust kernels
(`Solver.add_term(term, kernel=...)` + `ConcreteTermEvalReturn.apply_robust_kernel`)
and ships a `HuberRobustKernel`, but no caller ever passes one — the IRLS
machinery is effectively unused. This PR:

1. Wires `ba.robust_kernel` / `ba.robust_kernel_threshold` from the SLAM
   config into `GraphBuffer.bundle_adjustment` so `DenseDepthFlowTerm`
   (dense flow and, if enabled, sparse tracks) receives the kernel.
2. Parameterises `HuberRobustKernel.threshold` (was hard-coded to 1,
   which is too tight for the /8 feature-grid residuals).
3. Adds two kernels for handling dynamic content and long-baseline drift:
   - `TukeyRobustKernel(c)` — biweight, hard-rejects `|r| > c`.
   - `TLSGncRobustKernel(c_bar, mu_init, mu_step, mu_max)` — Graduated
     Non-Convexity with Truncated Least Squares
     ([Yang-Antonante-Tzoumas-Carlone, RA-L 2020](https://arxiv.org/abs/1909.08605);
     weights / schedule follow GTSAM's
     [`GncOptimizer.h`](https://github.com/borglab/gtsam/blob/develop/gtsam/nonlinear/GncOptimizer.h)).
     The BA loop gains a μ-outer / GN-inner nesting: each μ level runs
     `n_iters // gnc_n_mu_steps` Gauss-Newton iterations at frozen μ,
     then μ advances multiplicatively toward the hard-TLS limit.

Default `robust_kernel: null` reproduces the pre-PR L2 behaviour bit-for-bit.

## Changes

Two atomic commits:

- **1/2** `feat(ba): parameterize HuberRobustKernel and wire into DenseDepthFlowTerm`
  — activates the existing kernel infra with Huber only. (+76 / −8)
- **2/2** `feat(ba): add Tukey and GNC-TLS robust kernels with mu-outer / GN-inner schedule`
  — adds the two kernels and the GNC schedule loop. (+196 / −10)

No changes to `solver.py`, `terms.py`, or any consumer outside
`GraphBuffer.bundle_adjustment`. No new dependencies.

## Benchmark

**Protocol**: 5 datasets × 2 clips × 201 frames @ 10 Hz (20 s each) = 10 clips.
Config: `configs/slam/default.yaml` defaults (`keyframe_depth=metric3d-small`,
`backend_iters=24`), varying only `ba.robust_kernel`. For GNC-TLS the BA
loop runs `gnc_n_mu_steps × gnc_gn_iters_per_mu = 4 × 6 = 24` GN iterations
per call (matches the default `backend_iters=24` used here).

**Metrics** (lower-is-better except mAA):

- `ATE_se3`: SE(3)-aligned absolute trajectory RMSE normalised by GT path
  length. Alignment leaves scale unchanged, so this exposes monocular
  scale drift.
- `RTE` / `RRE°`: median relative translation / rotation error across
  strides {10, 50, 100} frames.
- `mAA@τ`: AUC of consecutive-frame rotation accuracy under τ°.

### Overall (mean over 10 clips)

| Kernel | ATE_se3 ↓ | RTE ↓ | RRE° ↓ | mAA@3° ↑ | mAA@10° ↑ | ms/frame |
|---|---|---|---|---|---|---|
| **None** (L2) | 0.3766 | 1.5731 | 3.56 | 0.833 | 0.945 | 390 |
| **Huber** | 0.3713 | 1.5559 | **3.49** | 0.833 | 0.945 | 368 |
| **Tukey** | **0.3432** | **1.4745** | 3.66 | 0.836 | 0.941 | 373 |
| **GNC-TLS** | 0.3552 | 1.5083 | 3.62 | 0.836 | 0.943 | 390 |

### Relative vs L2

| Kernel | ATE_se3 | RTE | RRE | mAA@3° | mAA@10° |
|---|---|---|---|---|---|
| **Huber** | −1.4 % | −1.1 % | −2.1 % | ±0 % | ±0 % |
| **Tukey** | **−8.9 %** | **−6.3 %** | +2.6 % | +0.4 % | −0.4 % |
| **GNC-TLS** | −5.7 % | −4.1 % | +1.7 % | +0.3 % | −0.3 % |

### Per-dataset (2 clips each)

| Dataset | Scene | Kernel | ATE_se3 ↓ | RTE ↓ | RRE° ↓ | mAA@3° ↑ |
|---|---|---|---|---|---|---|
| KITTI-360 | driving | None | 0.0337 | 0.1535 | 1.05 | 0.985 |
| KITTI-360 | driving | Huber | **0.0280** | **0.1397** | 1.05 | 0.985 |
| KITTI-360 | driving | Tukey | 0.0909 | **0.1336** | 1.05 | 0.981 |
| KITTI-360 | driving | GNC-TLS | 0.0795 | 0.1345 | 1.05 | 0.983 |
| OpenLORIS | indoor | None | **0.0160** | **0.0864** | **0.93** | 0.956 |
| OpenLORIS | indoor | Huber | 0.0167 | 0.0886 | 0.94 | 0.956 |
| OpenLORIS | indoor | Tukey | 0.0175 | 0.0901 | 0.96 | 0.956 |
| OpenLORIS | indoor | GNC-TLS | 0.0172 | 0.0904 | 0.94 | 0.956 |
| OxfordSpires | walking SfM | None | **0.7229** | 2.3828 | 7.73 | 0.535 |
| OxfordSpires | walking SfM | Huber | 0.7325 | **2.3631** | **7.69** | 0.539 |
| OxfordSpires | walking SfM | Tukey | 0.7718 | 2.7057 | 8.41 | 0.520 |
| OxfordSpires | walking SfM | GNC-TLS | 0.8011 | 2.7349 | 8.23 | 0.519 |
| GrandTour | wide-FOV | None | 0.8881 | 4.5513 | 6.49 | 0.785 |
| GrandTour | wide-FOV | Huber | 0.8662 | 4.5371 | 6.49 | 0.785 |
| GrandTour | wide-FOV | Tukey | **0.6385** | **3.8496** | 6.45 | 0.785 |
| GrandTour | wide-FOV | GNC-TLS | 0.7016 | 4.0631 | **6.44** | 0.786 |
| InCrowd-VI | dense pedestrians | None | 0.2223 | 0.6916 | 1.62 | 0.904 |
| InCrowd-VI | dense pedestrians | Huber | 0.2130 | 0.6511 | **1.28** | 0.898 |
| InCrowd-VI | dense pedestrians | Tukey | 0.1971 | 0.5935 | 1.43 | **0.940** |
| InCrowd-VI | dense pedestrians | GNC-TLS | **0.1767** | **0.5184** | 1.46 | 0.935 |

**Takeaways**:

- **Huber** is Pareto-safe: −1 % to −2 % across all aggregate metrics,
  never worse than L2 by more than noise floor on any dataset.
- **Tukey / GNC-TLS** shine on dynamic / drift-heavy scenes — InCrowd-VI
  ATE_se3 −21 %, GrandTour ATE_se3 −28 %. They hurt on low-parallax
  static outdoor (KITTI ATE_se3 +169 % for Tukey) where aggressive
  outlier rejection discards valid long-tail residuals. Recommended as
  opt-in for domains known to contain dynamic content.

Kernel `apply` costs < 1 % of BA iteration time; the 0–6 % ms/frame
variation is within per-clip noise.

## Backward compatibility

`ba.robust_kernel: null` (default) → `build_robust_kernel` returns `None`
→ `Solver.run_inplace` skips `apply_robust_kernel` → identical linear
system as before.
