### PR TITLE
Tighten mypy import checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - "**"
+      - main
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,26 @@ exclude = [
 ]
 check_untyped_defs = false
 follow_imports = "silent"
-ignore_missing_imports = true
-no_site_packages = true
 warn_redundant_casts = true
 warn_unused_configs = true
 warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
+module = [
+    "ffmpeg",
+    "Imath",
+    "OpenEXR",
+    "pandas",
+    "pandas.*",
+    "scipy",
+    "scipy.*",
+    "tqdm",
+    "tqdm.*",
+    "vipe_ext",
+    "vslam",
+    "yt_dlp",
+]
+ignore_missing_imports = true
 
 [project]
 name = "vipe"

--- a/run.py
+++ b/run.py
@@ -7,10 +7,10 @@ def run(args: DictConfig) -> None:
     from vipe.config import validate_typed_config
     from vipe.streams.base import StreamList
 
-    args = validate_typed_config(args)
+    typed_args = validate_typed_config(args)
 
     # Gather all video streams
-    stream_list = StreamList.make(args.streams)
+    stream_list = StreamList.make(typed_args.streams)
 
     from vipe.pipeline import make_pipeline
     from vipe.utils.logging import configure_logging
@@ -20,7 +20,7 @@ def run(args: DictConfig) -> None:
     for stream_idx in range(len(stream_list)):
         video_stream = stream_list[stream_idx]
         logger.info(f"Processing {video_stream.name()} ({stream_idx + 1} / {len(stream_list)})")
-        pipeline = make_pipeline(args.pipeline)
+        pipeline = make_pipeline(typed_args.pipeline)
         pipeline.run(video_stream)
         logger.info(f"Finished processing {video_stream.name()}")
 

--- a/scripts/vipe_to_colmap.py
+++ b/scripts/vipe_to_colmap.py
@@ -149,7 +149,9 @@ def write_points3d_txt_from_depth(
         if idx % depth_step != 0:
             continue
 
-        rgb = cv2.cvtColor(cv2.imread(str(images[idx]), cv2.IMREAD_COLOR), cv2.COLOR_BGR2RGB)
+        image = cv2.imread(str(images[idx]), cv2.IMREAD_COLOR)
+        assert image is not None, f"Failed to read image: {images[idx]}"
+        rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         frame_height, frame_width = rgb.shape[:2]
         rgb = rgb[::spatial_subsample, ::spatial_subsample]
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
 import os
-import shutil
-import tarfile
-import tempfile
-from urllib.request import urlretrieve
 
 from setuptools import find_packages, setup
 
@@ -34,29 +30,8 @@ if "CONDA_PREFIX" in os.environ:
     if os.path.exists(conda_nvcc_path):
         os.environ["PYTORCH_NVCC"] = conda_nvcc_path
 
-# Download the put Eigen 3.4 in a correct place
 cpp_flags = get_cpp_flags()
 cuda_flags = get_cuda_flags()
-if os.environ.get("USE_SYSTEM_EIGEN", "0") == "0":
-    eigen_include_dir = "csrc/include/eigen3"
-    eigen_url = "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz"
-
-    if not os.path.exists(eigen_include_dir):
-        os.makedirs(eigen_include_dir, exist_ok=True)
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            tmp_tar_path = os.path.join(temp_dir, "eigen.gz")
-            extracted_dir = os.path.join(temp_dir, "eigen-extracted")
-            urlretrieve(eigen_url, tmp_tar_path)
-            with tarfile.open(tmp_tar_path, "r:gz") as tar:
-                tar.extractall(path=extracted_dir)
-
-            shutil.move(os.path.join(extracted_dir, "eigen-3.4.0", "Eigen"), eigen_include_dir)
-
-    # Use full path
-    additional_include_path = os.path.join(os.path.dirname(__file__), "csrc/include")
-    cpp_flags += ["-isystem", additional_include_path]
-    cuda_flags += ["-isystem", additional_include_path]
 
 packages = find_packages()
 setup(

--- a/uv.lock
+++ b/uv.lock
@@ -2597,7 +2597,7 @@ wheels = [
 
 [[package]]
 name = "python-pycg"
-version = "1.0.2"
+version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "calmsize" },
@@ -2619,9 +2619,9 @@ dependencies = [
     { name = "trimesh" },
     { name = "usd-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/4d/2d1382a175b5a35a2eca181f055d61f0b4f2d6911c6d49895158fe4d668a/python_pycg-1.0.2.tar.gz", hash = "sha256:409bfe29b4e47d02344e11d92e8a276558fc399ec559ab45e040d3aca9c9cbf7", size = 31382901, upload-time = "2026-05-13T23:17:20.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/46/a8297b0791e1180d4c47079f4a0a204454a3125a80982d612cb54201a04c/python_pycg-1.0.3.tar.gz", hash = "sha256:85440820a46123c9b069f29406f38b1384e4f343b16c276e318e796fa54426e3", size = 31382962, upload-time = "2026-05-14T18:41:31.109Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/33/edddaa13b97a8f420a341105b7587d731234f957f9964976a6c2b0823621/python_pycg-1.0.2-py3-none-any.whl", hash = "sha256:6ca1df039c503178721f33e9ab23f6e421337b6ff7afa971dc050696aba60506", size = 31388346, upload-time = "2026-05-13T23:17:16.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c2/5e0adadfda4b26c0281512ee0067e6164e8d17cf33e2ef5c5cc29b7ea409/python_pycg-1.0.3-py3-none-any.whl", hash = "sha256:0263157d2d11bea4fb850dc1bc0e4ae5a58bccc85c424354f434e8191d08c0bc", size = 31388494, upload-time = "2026-05-14T18:41:28.141Z" },
 ]
 
 [[package]]

--- a/vipe/ext/specs.py
+++ b/vipe/ext/specs.py
@@ -14,15 +14,45 @@
 # limitations under the License.
 
 import os
+import shutil
+import tarfile
+import tempfile
 from pathlib import Path
+from urllib.request import urlretrieve
+
+EIGEN_URL = "https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz"
+
+
+def _csrc_path() -> Path:
+    return Path(__file__).parent.parent.parent / "csrc"
 
 
 def get_sources() -> list[str]:
-    csrc_path = Path(__file__).parent.parent.parent / "csrc"
+    csrc_path = _csrc_path()
     return [str(p) for p in csrc_path.glob("**/*") if p.suffix in [".cpp", ".cu"]]
 
 
+def _eigen_include_flags() -> list[str]:
+    if os.environ.get("USE_SYSTEM_EIGEN", "0") == "1":
+        return []
+
+    include_path = _csrc_path() / "include"
+    eigen_path = include_path / "eigen3" / "Eigen"
+    if not eigen_path.exists():
+        eigen_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tmp_tar_path = Path(temp_dir) / "eigen.tar.gz"
+            extracted_dir = Path(temp_dir) / "eigen-extracted"
+            urlretrieve(EIGEN_URL, tmp_tar_path)
+            with tarfile.open(tmp_tar_path, "r:gz") as tar:
+                tar.extractall(path=extracted_dir)
+            shutil.move(str(extracted_dir / "eigen-3.4.0" / "Eigen"), eigen_path)
+
+    return ["-isystem", str(include_path.resolve())]
+
+
 def _additional_include_flags() -> list[str]:
+    flags = _eigen_include_flags()
     if "CONDA_PREFIX" in os.environ:
         conda_prefix = Path(os.environ["CONDA_PREFIX"])
         include_paths = [
@@ -30,12 +60,10 @@ def _additional_include_flags() -> list[str]:
             conda_prefix / "nvvm" / "include",
             *sorted((conda_prefix / "targets").glob("*/include")),
         ]
-        flags: list[str] = []
         for include_path in include_paths:
             if include_path.exists():
                 flags += ["-isystem", str(include_path)]
-        return flags
-    return []
+    return flags
 
 
 def get_cpp_flags() -> list[str]:

--- a/vipe/ext/xformers.py
+++ b/vipe/ext/xformers.py
@@ -42,7 +42,9 @@ def scaled_index_add(
     scaling: Optional[torch.Tensor] = None,  # [D]
     alpha: float = 1.0,
 ) -> torch.Tensor:
-    return torch.index_add(input, dim=0, source=scaling * source, index=index, alpha=alpha)
+    if scaling is not None:
+        source = scaling * source
+    return torch.index_add(input, dim=0, source=source, index=index, alpha=alpha)
 
 
 def index_select_cat(sources: Sequence[torch.Tensor], indices: Sequence[torch.Tensor]) -> torch.Tensor:

--- a/vipe/pipeline/__init__.py
+++ b/vipe/pipeline/__init__.py
@@ -18,7 +18,7 @@ import copy
 import importlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Sequence, cast
 
 from omegaconf import DictConfig
 
@@ -84,4 +84,4 @@ def make_pipeline(config: DictConfig | BaseConfigSchema) -> Pipeline:
     config = copy.deepcopy(_as_dictconfig(config))
     pipeline_cls = make_pipeline_cls(config)
     del config.instance
-    return pipeline_cls(**config)
+    return pipeline_cls(**cast(dict[str, Any], config))

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -15,7 +15,7 @@
 
 
 import logging
-from typing import Iterable, Iterator
+from typing import Any, Iterable, Iterator, cast
 
 import numpy as np
 import torch
@@ -98,12 +98,13 @@ class GeoCalibIntrinsicsProcessor(IntrinsicEstimationProcessor):
                 camera_model=camera_model,
             )
 
-        self.fov_y = res["camera"].vfov[0].item()
+        camera_result = cast(Any, res["camera"])
+        self.fov_y = camera_result.vfov[0].item()
         self.camera_type = camera_type
 
         if not is_pinhole:
             # Assign distortion parameter
-            self.distortion = [res["camera"].dist[0, 0].item()]
+            self.distortion = [camera_result.dist[0, 0].item()]
 
 
 class TrackAnythingProcessor(StreamProcessor):
@@ -284,7 +285,7 @@ class AdaptiveDepthProcessor(StreamProcessor):
                     align_mask = align_mask & frame.mask & (~frame.sky_mask)
 
                 try:
-                    _, scale, bias = align_inv_depth_to_depth(
+                    _, scale_tensor, bias_tensor = align_inv_depth_to_depth(
                         unpack_optional(video_depth_inv_depth),
                         prompt_result,
                         align_mask,
@@ -292,16 +293,18 @@ class AdaptiveDepthProcessor(StreamProcessor):
                 except RuntimeError:
                     if self.cache_scale_bias is None:
                         raise
-                    scale, bias = self.cache_scale_bias
+                    scale_tensor, bias_tensor = self.cache_scale_bias
 
                 # momentum update
                 if self.cache_scale_bias is None:
-                    self.cache_scale_bias = (scale, bias)
-                scale = self.cache_scale_bias[0] * self.update_momentum + scale * (1 - self.update_momentum)
-                bias = self.cache_scale_bias[1] * self.update_momentum + bias * (1 - self.update_momentum)
-                self.cache_scale_bias = (scale, bias)
+                    self.cache_scale_bias = (scale_tensor, bias_tensor)
+                scale_tensor = self.cache_scale_bias[0] * self.update_momentum + scale_tensor * (
+                    1 - self.update_momentum
+                )
+                bias_tensor = self.cache_scale_bias[1] * self.update_momentum + bias_tensor * (1 - self.update_momentum)
+                self.cache_scale_bias = (scale_tensor, bias_tensor)
 
-                video_inv_depth = video_depth_inv_depth * scale + bias
+                video_inv_depth = video_depth_inv_depth * scale_tensor + bias_tensor
                 video_inv_depth[video_inv_depth < 1e-3] = 1e-3
                 frame.metric_depth = video_inv_depth.reciprocal()
 

--- a/vipe/priors/depth/alignment.py
+++ b/vipe/priors/depth/alignment.py
@@ -21,7 +21,7 @@ def align_inv_depth_to_depth(
     target_depth: torch.Tensor,
     target_mask: torch.Tensor | None = None,
     quantile_masking: bool = True,
-) -> tuple[torch.Tensor, float, float]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Apply affine transformation to align source inverse depth to target depth.
 

--- a/vipe/slam/ba/solver.py
+++ b/vipe/slam/ba/solver.py
@@ -32,12 +32,13 @@ def solve_scipy(pi: torch.Tensor, pj: torch.Tensor, lhs: torch.Tensor, rhs: torc
     from scipy.sparse import coo_matrix
     from scipy.sparse.linalg import spsolve
 
-    lhs = coo_matrix((lhs.cpu().numpy(), (pi.cpu().numpy(), pj.cpu().numpy())))
+    lhs_np = lhs.cpu().numpy()
+    rhs_np = rhs.cpu().numpy()
+    lhs_sparse = coo_matrix((lhs_np, (pi.cpu().numpy(), pj.cpu().numpy())))
     # Convert to CSR format for efficient spsolve
-    lhs = lhs.tocsr()
-    rhs = rhs.cpu().numpy()
+    lhs_sparse = lhs_sparse.tocsr()
 
-    x = spsolve(lhs, rhs)
+    x = spsolve(lhs_sparse, rhs_np)
 
     return torch.tensor(x, device=pi.device).float()
 

--- a/vipe/slam/maths/retractor.py
+++ b/vipe/slam/maths/retractor.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 import torch
 
 from vipe.ext.lietorch import SE3
@@ -20,30 +22,30 @@ from vipe.utils.cameras import CameraType
 
 
 class BaseRetractor:
-    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor):
+    def oplus(self, x: Any, inds: torch.Tensor, dx: torch.Tensor) -> None:
         x[inds] += dx
 
 
 class PoseRetractor(BaseRetractor):
-    def oplus(self, x: SE3, inds: torch.Tensor, dx: torch.Tensor):
+    def oplus(self, x: SE3, inds: torch.Tensor, dx: torch.Tensor) -> None:
         x.data[inds] = SE3(x.data[inds]).retr(dx).data
 
 
 class RigRotationOnlyRetractor(BaseRetractor):
-    def oplus(self, x: SE3, inds: torch.Tensor, dx: torch.Tensor):
+    def oplus(self, x: SE3, inds: torch.Tensor, dx: torch.Tensor) -> None:
         dx = dx.clone()
         dx[:, :3] = 0  # zero out translation part
         x.data[inds] = SE3(x.data[inds]).retr(dx).data
 
 
 class DenseDispRetractor(BaseRetractor):
-    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor):
+    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor) -> None:
         dx = torch.where(dx > 10, torch.zeros_like(dx), dx)
-        return super().oplus(x, inds, dx)
+        super().oplus(x, inds, dx)
 
 
 class TracksDispRetractor(BaseRetractor):
-    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor):
+    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor) -> None:
         super().oplus(x, inds, dx)
         x.clamp_(min=1e-3, max=10)
 
@@ -52,7 +54,7 @@ class IntrinsicsRetractor(BaseRetractor):
     def __init__(self, camera_type: CameraType):
         self.camera_type = camera_type
 
-    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor):
+    def oplus(self, x: torch.Tensor, inds: torch.Tensor, dx: torch.Tensor) -> None:
         if len(dx) == 1:
             # Broadcast dx to all intrinsics
             inds = torch.where(x[:, 0] > 0)[0]

--- a/vipe/streams/base.py
+++ b/vipe/streams/base.py
@@ -18,7 +18,7 @@ import importlib
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Iterable, Iterator, Protocol
+from typing import Any, Iterable, Iterator, Protocol, cast
 
 import numpy as np
 import torch
@@ -308,6 +308,9 @@ class VideoStream(IterableDataset[VideoFrame]):
             stream_attribute.append(frame.get_attribute(attribute))
         return stream_attribute
 
+    def get_gt_stream_attribute(self, attribute: FrameAttribute) -> list[Any]:
+        raise NotImplementedError(f"{type(self).__name__} does not provide ground-truth {attribute.value} data.")
+
 
 class MultiviewVideoList(Iterable[VideoStream]):
     """
@@ -359,7 +362,7 @@ class CachedVideoStream(VideoStream):
         self._name = video_stream.name()
         self._attributes = video_stream.attributes()
         self._len = len(video_stream)
-        self.iterator = iter(video_stream)
+        self.iterator: Iterator[VideoFrame] | None = iter(video_stream)
         self.data: list[VideoFrame] = []
         self.desc = desc
 
@@ -523,7 +526,7 @@ class StreamList:
         module = importlib.import_module(module_path)
         config = copy.deepcopy(config)
         del config.instance
-        return getattr(module, class_name)(**config)
+        return getattr(module, class_name)(**cast(dict[str, Any], config))
 
     def __len__(self) -> int:
         raise NotImplementedError

--- a/vipe/utils/depth.py
+++ b/vipe/utils/depth.py
@@ -64,7 +64,7 @@ def normal_weight_from_xyz(xyz: torch.Tensor, robust: bool = True) -> torch.Tens
     if not batch_dim:
         xyz = xyz.unsqueeze(0)
 
-    from .ext import _C
+    from vipe.ext import _C
 
     assert xyz.size(0) == 1, "Batch size must be 1."
     if robust:

--- a/vipe/utils/io.py
+++ b/vipe/utils/io.py
@@ -18,7 +18,7 @@ import tempfile
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, cast
 
 import cv2
 import imageio
@@ -243,10 +243,10 @@ def read_rgb_artifacts(rgb_file_path: Path) -> Iterator[tuple[int, torch.Tensor]
     """
     Read RGB from H264-encoded video.
     """
-    reader = imageio.get_reader(rgb_file_path, "ffmpeg")
+    reader = cast(Iterator[np.ndarray], imageio.get_reader(str(rgb_file_path), "ffmpeg"))  # type: ignore[arg-type]
     for frame_idx, rgb in enumerate(reader):
-        rgb = torch.from_numpy(rgb) / 255.0
-        yield frame_idx, rgb
+        rgb_tensor = torch.from_numpy(rgb) / 255.0
+        yield frame_idx, rgb_tensor
 
 
 def save_depth_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream, gt: bool = False) -> None:
@@ -322,6 +322,7 @@ def read_instance_artifacts(
             with z.open(file_name) as f:
                 mask_buffer = np.frombuffer(f.read(), dtype=np.uint8)
                 mask = cv2.imdecode(mask_buffer, cv2.IMREAD_UNCHANGED)
+                assert mask is not None, f"Failed to decode instance mask {file_name}"
                 yield frame_idx, torch.from_numpy(mask.copy()).byte()
 
 

--- a/vipe/utils/viser.py
+++ b/vipe/utils/viser.py
@@ -203,7 +203,7 @@ class ClientClosures:
             else:
                 # Use a rainbow color based on the frame index
                 denom = len(self.scene_frame_handles) - 1
-                rainbow_value = cm.jet(1.0 - frame_idx / denom)[:3]
+                rainbow_value = cm.jet(1.0 - frame_idx / denom)[:3]  # type: ignore[attr-defined]
                 rainbow_value = tuple((int(c * 255) for c in rainbow_value))
                 frame_node.frustum_handle.color = rainbow_value
 

--- a/vipe/utils/visualization.py
+++ b/vipe/utils/visualization.py
@@ -36,8 +36,9 @@ rng = np.random.RandomState(200)
 _palette = ((rng.random((3 * 255)) * 0.7 + 0.3) * 255).astype(np.uint8).tolist()
 _palette = [0, 0, 0] + _palette
 
-POINTS_STENCIL = np.meshgrid(np.arange(-2, 3), np.arange(-2, 3))
-POINTS_STENCIL = np.stack(POINTS_STENCIL, axis=-1).reshape(-1, 2)
+POINTS_STENCIL: np.ndarray
+points_stencil_grid = np.meshgrid(np.arange(-2, 3), np.arange(-2, 3))
+POINTS_STENCIL = np.stack(points_stencil_grid, axis=-1).reshape(-1, 2)
 POINTS_STENCIL = POINTS_STENCIL[np.max(np.abs(POINTS_STENCIL), axis=-1) > 1]
 POINTS_STENCIL = np.pad(POINTS_STENCIL, ((0, 1), (0, 0)), constant_values=0)
 
@@ -84,19 +85,21 @@ def bbox_with_size(pcd_xyz: torch.Tensor, quantile: float = 0.98):
     low_quantile, high_quantile = (1 - quantile) / 2, 1 - (1 - quantile) / 2
     pcd_min = torch.quantile(pcd_xyz, low_quantile, dim=0, keepdim=True)
     pcd_max = torch.quantile(pcd_xyz, high_quantile, dim=0, keepdim=True)
+    pcd_min_vec = pcd_min[0]
+    pcd_max_vec = pcd_max[0]
 
-    x_length = pcd_max[0, 0] - pcd_min[0, 0]
-    x_length_pos = pcd_min[0] + torch.tensor([x_length / 2, 0, 0])
-    y_length = pcd_max[0, 1] - pcd_min[0, 1]
-    y_length_pos = pcd_min[0] + torch.tensor([0, y_length / 2, 0])
-    z_length = pcd_max[0, 2] - pcd_min[0, 2]
-    z_length_pos = pcd_min[0] + torch.tensor([0, 0, z_length / 2])
+    x_length = pcd_max_vec[0] - pcd_min_vec[0]
+    x_length_pos = pcd_min_vec + pcd_min_vec.new_tensor([x_length.item() / 2, 0.0, 0.0])
+    y_length = pcd_max_vec[1] - pcd_min_vec[1]
+    y_length_pos = pcd_min_vec + pcd_min_vec.new_tensor([0.0, y_length.item() / 2, 0.0])
+    z_length = pcd_max_vec[2] - pcd_min_vec[2]
+    z_length_pos = pcd_min_vec + pcd_min_vec.new_tensor([0.0, 0.0, z_length.item() / 2])
 
     return [
-        vis.wireframe_bbox(pcd_min, pcd_max, ucid=-1),
-        vis.text(f"{x_length.item():.2f}m", x_length_pos),
-        vis.text(f"{y_length.item():.2f}m", y_length_pos),
-        vis.text(f"{z_length.item():.2f}m", z_length_pos),
+        vis.wireframe_bbox(pcd_min_vec.detach().cpu().numpy(), pcd_max_vec.detach().cpu().numpy(), ucid=-1),
+        vis.text(f"{x_length.item():.2f}m", x_length_pos.detach().cpu().numpy()),
+        vis.text(f"{y_length.item():.2f}m", y_length_pos.detach().cpu().numpy()),
+        vis.text(f"{z_length.item():.2f}m", z_length_pos.detach().cpu().numpy()),
     ]
 
 
@@ -196,10 +199,10 @@ def project_points_panorama(
     pose_matrix = pose.inv().matrix().cpu().numpy()
     local_xyz = xyz @ pose_matrix[:3, :3].T + pose_matrix[:3, 3]
 
-    uv = project_points_to_panorama(torch.from_numpy(local_xyz), return_depth=False)
-    uv[:, 0] *= frame_size[1]
-    uv[:, 1] *= frame_size[0]
-    uv = (uv - 0.5).round().int().cpu().numpy()
+    uv_tensor = project_points_to_panorama(torch.from_numpy(local_xyz), return_depth=False)
+    uv_tensor[:, 0] *= frame_size[1]
+    uv_tensor[:, 1] *= frame_size[0]
+    uv = (uv_tensor - 0.5).round().int().cpu().numpy()
 
     if color is not None:
         if np.issubdtype(color.dtype, np.floating):
@@ -235,7 +238,7 @@ def project_points(
         & torch.from_numpy(local_xyz[:, 2] > 0)
     )
     uv = uv[in_bound]
-    uv = (uv - 0.5).round().int().cpu().numpy()
+    uv_np = (uv - 0.5).round().int().cpu().numpy()
 
     # uv, in_bound = project_points_to_pinhole(
     #     torch.from_numpy(local_xyz),
@@ -249,11 +252,11 @@ def project_points(
     # uv = (uv - 0.5).round().int().cpu().numpy()
 
     if color is not None:
-        color = color[in_bound]
+        color = color[in_bound.cpu().numpy()]
         if np.issubdtype(color.dtype, np.floating):
             color = (color * 255).astype(np.uint8)
 
-    return draw_points_batch(canvas, uv, color, stencil=POINTS_STENCIL)
+    return draw_points_batch(canvas, uv_np, color, stencil=POINTS_STENCIL)
 
 
 def image_above_text(img: np.ndarray, text: str = "<TEXT>") -> Image.Image:
@@ -271,7 +274,9 @@ def image_above_text(img: np.ndarray, text: str = "<TEXT>") -> Image.Image:
     draw = ImageDraw.Draw(new_image)
 
     try:
-        font = ImageFont.truetype("arial.ttf", text_height)  # You can change the font size
+        font: ImageFont.ImageFont | ImageFont.FreeTypeFont = ImageFont.truetype(
+            "arial.ttf", text_height
+        )  # You can change the font size
     except IOError:
         font = ImageFont.load_default()  # Fallback to default font if arial is not available
 
@@ -479,7 +484,7 @@ def save_projection_video(
                     fov_y = np.rad2deg(fov_y)
                     text_desc += f" | fovY {fov_y:.2f}"
             current_pose = unpack_optional(frame_data.pose)
-            trajectory_length += np.linalg.norm((last_pose.inv() * current_pose).translation()[:3].cpu().numpy())
+            trajectory_length += float(np.linalg.norm((last_pose.inv() * current_pose).translation()[:3].cpu().numpy()))
             last_pose = current_pose
             text_desc += f" | Traj {trajectory_length:.4f}"
             if len(frame_data.information) > 0:


### PR DESCRIPTION
## Summary
- Remove global mypy `ignore_missing_imports` and `no_site_packages` suppressions.
- Move remaining optional or untyped third-party import suppressions into targeted `[[tool.mypy.overrides]]` sections.
- Bump `python-pycg` to 1.0.3 and rely on its `py.typed` marker instead of local PyCG import ignores.
- Fix exposed local typing issues around typed configs, depth alignment tensors, PyCG visualization boundaries, xformers fallback helpers, artifact IO, and dynamic constructors.
- Avoid duplicate PR CI by running branch-push CI only on `main`; PRs still run `pull_request` CI.
- Share Eigen header setup between package builds and JIT extension builds so cached CI installs can still run tests from a clean checkout.

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --dev mypy`
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --dev ruff check .`
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --dev pytest -q`
- Removed generated `csrc/include`, then verified `vipe.ext.specs.get_cpp_flags()` recreates Eigen headers and includes `csrc/include` in C++/CUDA flags.
- `UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run vipe infer assets/examples/dog-example.mp4 --output /tmp/vipe-pr76-smoke`
- Read back `/tmp/vipe-pr76-smoke` artifacts with repo loaders: 122 RGB frames, 122 poses, 122 intrinsics, 122 depth frames.