### PR TITLE
Add dog example smoke test

### DIFF
--- a/.github/scripts/validate_smoke_output.py
+++ b/.github/scripts/validate_smoke_output.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import argparse
+import pickle
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from vipe.utils import io
+
+
+def _require_file(path: Path) -> None:
+    if not path.is_file():
+        raise AssertionError(f"Missing expected artifact: {path}")
+    if path.stat().st_size <= 0:
+        raise AssertionError(f"Artifact is empty: {path}")
+
+
+def _require_frame_indices(name: str, indices: np.ndarray, expected_frames: int) -> None:
+    expected = np.arange(expected_frames)
+    if indices.shape != expected.shape or not np.array_equal(indices, expected):
+        raise AssertionError(f"{name} frame indices are not exactly 0..{expected_frames - 1}: {indices}")
+
+
+def _require_tensor_count(name: str, items: list[tuple[int, torch.Tensor]], expected_frames: int) -> None:
+    indices = np.array([idx for idx, _ in items], dtype=np.int64)
+    _require_frame_indices(name, indices, expected_frames)
+
+
+def validate_smoke_output(base_path: Path, artifact_name: str, expected_frames: int) -> None:
+    artifact = io.ArtifactPath(base_path, artifact_name)
+
+    for path in [
+        artifact.rgb_path,
+        artifact.pose_path,
+        artifact.depth_path,
+        artifact.intrinsics_path,
+        artifact.camera_type_path,
+        artifact.mask_path,
+        artifact.mask_phrase_path,
+        artifact.meta_info_path,
+    ]:
+        _require_file(path)
+
+    rgb_frames = list(io.read_rgb_artifacts(artifact.rgb_path))
+    if len(rgb_frames) != expected_frames:
+        raise AssertionError(f"RGB artifact has {len(rgb_frames)} frames, expected {expected_frames}.")
+    if not all(frame.ndim == 3 and frame.shape[-1] == 3 for _, frame in rgb_frames):
+        raise AssertionError("RGB artifact contains frames with invalid shape.")
+
+    pose_npz = np.load(artifact.pose_path)
+    _require_frame_indices("pose", pose_npz["inds"], expected_frames)
+    pose = pose_npz["data"]
+    if pose.shape != (expected_frames, 4, 4) or not np.isfinite(pose).all():
+        raise AssertionError(f"Pose artifact has invalid shape or values: {pose.shape}.")
+    if not np.allclose(pose[:, 3], np.array([0.0, 0.0, 0.0, 1.0]), atol=1e-4):
+        raise AssertionError("Pose artifact does not contain valid homogeneous transforms.")
+
+    intr_npz = np.load(artifact.intrinsics_path)
+    _require_frame_indices("intrinsics", intr_npz["inds"], expected_frames)
+    intrinsics = intr_npz["data"]
+    if intrinsics.shape[0] != expected_frames or intrinsics.shape[1] < 4 or not np.isfinite(intrinsics).all():
+        raise AssertionError(f"Intrinsics artifact has invalid shape or values: {intrinsics.shape}.")
+    if not (intrinsics[:, 0] > 0).all() or not (intrinsics[:, 1] > 0).all():
+        raise AssertionError("Intrinsics artifact contains non-positive focal lengths.")
+
+    depth_frames = list(io.read_depth_artifacts(artifact.depth_path))
+    _require_tensor_count("depth", depth_frames, expected_frames)
+    depth_shape = depth_frames[0][1].shape
+    finite_depth_pixels = 0
+    positive_depth_pixels = 0
+    total_depth_pixels = 0
+    for _, depth in depth_frames:
+        if depth.shape != depth_shape or depth.ndim != 2:
+            raise AssertionError("Depth artifact contains inconsistent frame shapes.")
+        finite = torch.isfinite(depth)
+        finite_depth_pixels += int(finite.sum())
+        positive_depth_pixels += int((depth[finite] > 0).sum())
+        total_depth_pixels += depth.numel()
+    if finite_depth_pixels < int(0.99 * total_depth_pixels):
+        raise AssertionError("Depth artifact contains too many non-finite pixels.")
+    if positive_depth_pixels == 0:
+        raise AssertionError("Depth artifact contains no positive depth values.")
+
+    mask_frames = list(io.read_instance_artifacts(artifact.mask_path))
+    _require_tensor_count("mask", mask_frames, expected_frames)
+    for _, mask in mask_frames:
+        if mask.shape != depth_shape or mask.ndim != 2:
+            raise AssertionError("Mask artifact shape does not match depth shape.")
+
+    phrases = io.read_instance_phrases(artifact.mask_phrase_path)
+    if not phrases:
+        raise AssertionError("Instance phrase artifact is empty.")
+
+    with artifact.meta_info_path.open("rb") as f:
+        meta = pickle.load(f)
+    if not isinstance(meta, dict) or "ba_residual" not in meta:
+        raise AssertionError("Metadata artifact is missing ba_residual.")
+
+    discovered = list(io.ArtifactPath.glob_artifacts(base_path))
+    if not any(path.artifact_name == artifact_name for path in discovered):
+        raise AssertionError(f"{artifact_name} was not discoverable through ArtifactPath.glob_artifacts.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate ViPE dog-example smoke test artifacts.")
+    parser.add_argument("base_path", type=Path)
+    parser.add_argument("artifact_name")
+    parser.add_argument("--expected-frames", type=int, required=True)
+    args = parser.parse_args()
+
+    validate_smoke_output(args.base_path, args.artifact_name, args.expected_frames)
+    print(f"Validated {args.artifact_name} artifacts in {args.base_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,21 @@ jobs:
   test:
     name: Test
     runs-on: self-hosted
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
+      CUDA_HOME: /usr/local/cuda-12.8
       UV_CACHE_DIR: /tmp/uv-cache
       UV_LINK_MODE: copy
+      VIPE_SMOKE_OUTPUT: ci_outputs/dog-example-default
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Configure CUDA paths
+        run: |
+          echo "$CUDA_HOME/bin" >> "$GITHUB_PATH"
+          echo "LD_LIBRARY_PATH=$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -35,19 +42,93 @@ jobs:
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
-        run: uv sync --locked --dev --group docs
+        timeout-minutes: 30
+        run: uv sync --locked --dev --group docs --no-install-project
+
+      - name: Ensure PyTorch supports runner GPU
+        run: |
+          if ! uv run --no-sync python - <<'PY'
+          import sys
+          import torch
+
+          if not torch.cuda.is_available():
+              raise SystemExit("CUDA is required for the ViPE smoke test.")
+
+          major, minor = torch.cuda.get_device_capability(0)
+          device_arch = f"sm_{major}{minor}"
+          supported_arches = torch.cuda.get_arch_list()
+          print(f"device={torch.cuda.get_device_name(0)} arch={device_arch}")
+          print(f"torch={torch.__version__} cuda={torch.version.cuda} supported_arches={supported_arches}")
+          sys.exit(0 if device_arch in supported_arches else 1)
+          PY
+          then
+            echo "Installed PyTorch wheel does not support this runner GPU; installing a V100-compatible CUDA wheel."
+            uv pip install \
+              --index-url https://download.pytorch.org/whl/cu124 \
+              --extra-index-url https://pypi.org/simple \
+              --index-strategy unsafe-best-match \
+              --force-reinstall \
+              "torch==2.6.0+cu124" \
+              "torchvision==0.21.0+cu124"
+          fi
+
+          uv run --no-sync python - <<'PY' >> "$GITHUB_ENV"
+          import torch
+
+          major, minor = torch.cuda.get_device_capability(0)
+          device_arch = f"sm_{major}{minor}"
+          supported_arches = torch.cuda.get_arch_list()
+          print(f"TORCH_CUDA_ARCH_LIST={major}.{minor}")
+          if device_arch not in supported_arches:
+              raise SystemExit(f"PyTorch still does not support runner GPU arch {device_arch}: {supported_arches}")
+          PY
+
+      - name: Install ViPE package
+        timeout-minutes: 20
+        run: uv pip install --no-build-isolation -e .
 
       - name: Lint
-        run: uv run --dev ruff check .
+        run: uv run --no-sync ruff check .
 
       - name: Type check
-        run: uv run --dev mypy
+        run: uv run --no-sync mypy
 
       - name: Check generated docs
-        run: uv run --dev --group docs python scripts/generate_config_docs.py --check
+        run: uv run --no-sync python scripts/generate_config_docs.py --check
 
       - name: Build docs
-        run: uv run --dev --group docs mkdocs build --strict
+        run: uv run --no-sync mkdocs build --strict
 
       - name: Test
-        run: uv run --dev pytest -q
+        timeout-minutes: 20
+        run: uv run --no-sync pytest -q
+
+      - name: Run dog-example smoke test
+        timeout-minutes: 45
+        run: |
+          rm -rf "$VIPE_SMOKE_OUTPUT"
+          uv run --no-sync python run.py \
+            pipeline=default \
+            streams=raw_mp4_stream \
+            streams.base_path=assets/examples/dog-example.mp4 \
+            streams.frame_end=64 \
+            pipeline.output.path="$VIPE_SMOKE_OUTPUT" \
+            pipeline.output.save_artifacts=true \
+            pipeline.output.save_viz=false \
+            pipeline.slam.visualize=false
+
+      - name: Validate dog-example smoke output
+        run: |
+          uv run --no-sync python .github/scripts/validate_smoke_output.py \
+            "$VIPE_SMOKE_OUTPUT" \
+            dog-example \
+            --expected-frames 64
+
+      - name: Upload dog-example smoke output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dog-example-smoke-output
+          path: ${{ env.VIPE_SMOKE_OUTPUT }}
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,8 @@ cython_debug/
 playground.py
 TODO.md
 vipe_results/
+vipe_results*/
+ci_outputs/
 /try_*.py
 /external/
 JIAHUI.md

--- a/vipe/priors/track_anything/__init__.py
+++ b/vipe/priors/track_anything/__init__.py
@@ -33,9 +33,8 @@ class TrackAnythingPipeline:
         if not aot_ckpt_path.exists():
             aot_ckpt_path.parent.mkdir(parents=True, exist_ok=True)
             gdown.download(
-                "https://drive.google.com/file/d/1QoChMkTVxdYZ_eBlZhK2acq9KMQZccPJ/view",
+                id="1QoChMkTVxdYZ_eBlZhK2acq9KMQZccPJ",
                 output=str(aot_ckpt_path),
-                fuzzy=True,
             )
 
         self.threshold_args = {

--- a/vipe/slam/networks/droid_net.py
+++ b/vipe/slam/networks/droid_net.py
@@ -535,9 +535,8 @@ class DroidNet(nn.Module):
         if not ckpt_path.exists():
             ckpt_path.parent.mkdir(parents=True, exist_ok=True)
             gdown.download(
-                "https://drive.google.com/file/d/1PpqVt1H4maBa_GbPJp4NwxRsd9jk-elh/view",
+                id="1PpqVt1H4maBa_GbPJp4NwxRsd9jk-elh",
                 output=str(ckpt_path),
-                fuzzy=True,
             )
 
         state_dict = OrderedDict(


### PR DESCRIPTION
## Summary
- add a CI smoke run for the default pipeline on assets/examples/dog-example.mp4 limited to 64 frames
- save artifacts during the smoke run and validate RGB, pose, intrinsics, depth, mask, phrases, and metadata
- ignore generated CI/output artifact directories

## Local validation
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy uv run --dev ruff check .
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy CUDA_HOME=/usr/local/cuda-12.8 uv run --dev pytest -q
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy CUDA_HOME=/usr/local/cuda-12.8 uv run --dev python run.py pipeline=default streams=raw_mp4_stream streams.base_path=assets/examples/dog-example.mp4 streams.frame_end=64 pipeline.output.path=ci_outputs/dog-example-default pipeline.output.save_artifacts=true pipeline.output.save_viz=false pipeline.slam.visualize=false
- UV_CACHE_DIR=/tmp/uv-cache UV_LINK_MODE=copy CUDA_HOME=/usr/local/cuda-12.8 uv run --dev python .github/scripts/validate_smoke_output.py ci_outputs/dog-example-default dog-example --expected-frames 64
