### PR TITLE
Add indexed AltCorr default path

### DIFF
--- a/csrc/droid_net_ext/altcorr_kernel.cu
+++ b/csrc/droid_net_ext/altcorr_kernel.cu
@@ -138,6 +138,108 @@ __global__ void altcorr_forward_kernel(const torch::PackedTensorAccessor32<scala
 }
 
 template <typename scalar_t>
+__global__ void altcorr_index_forward_kernel(
+    const torch::PackedTensorAccessor32<scalar_t, 5, torch::RestrictPtrTraits> fmap1,
+    const torch::PackedTensorAccessor32<scalar_t, 5, torch::RestrictPtrTraits> fmap2,
+    const torch::PackedTensorAccessor32<float, 5, torch::RestrictPtrTraits> coords,
+    const torch::PackedTensorAccessor32<int64_t, 1, torch::RestrictPtrTraits> ii,
+    const torch::PackedTensorAccessor32<int64_t, 1, torch::RestrictPtrTraits> jj,
+    torch::PackedTensorAccessor32<float, 5, torch::RestrictPtrTraits> corr, int r, int level_offset,
+    float coord_scale) {
+    const int bm = blockIdx.x;
+    const int m = bm % coords.size(1);
+    const int b = bm / coords.size(1);
+    const int src = static_cast<int>(ii[m]);
+    const int dst = static_cast<int>(jj[m]);
+    const int h0 = blockIdx.y * blockDim.x;
+    const int w0 = blockIdx.z * blockDim.y;
+    const int tid = threadIdx.x * blockDim.y + threadIdx.y;
+
+    const int H1 = coords.size(2);
+    const int W1 = coords.size(3);
+    const int H2 = fmap2.size(2);
+    const int W2 = fmap2.size(3);
+    const int C = fmap1.size(4);
+
+    __shared__ scalar_t f1[CHANNEL_STRIDE][BLOCK_HW];
+    __shared__ scalar_t f2[CHANNEL_STRIDE][BLOCK_HW];
+
+    __shared__ float x2s[BLOCK_HW];
+    __shared__ float y2s[BLOCK_HW];
+
+    const int h1 = h0 + threadIdx.x;
+    const int w1 = w0 + threadIdx.y;
+    const bool valid1 = within_bounds(h1, w1, H1, W1);
+
+    if (valid1) {
+        x2s[tid] = coords[b][m][h1][w1][0] / coord_scale;
+        y2s[tid] = coords[b][m][h1][w1][1] / coord_scale;
+    } else {
+        x2s[tid] = 0.0f;
+        y2s[tid] = 0.0f;
+    }
+
+    const float x2 = x2s[tid];
+    const float y2 = y2s[tid];
+    const float dx = x2 - floorf(x2);
+    const float dy = y2 - floorf(y2);
+    const int rd = 2 * r + 1;
+
+    for (int c = 0; c < C; c += CHANNEL_STRIDE) {
+        for (int k = 0; k < BLOCK_HW; k += BLOCK_HW / CHANNEL_STRIDE) {
+            int k1 = k + tid / CHANNEL_STRIDE;
+            int hk = h0 + k1 / BLOCK_W;
+            int wk = w0 + k1 % BLOCK_W;
+            int c1 = c + tid % CHANNEL_STRIDE;
+
+            if (within_bounds(hk, wk, H1, W1) && c1 < C)
+                f1[tid % CHANNEL_STRIDE][k1] = fmap1[b][src][hk][wk][c1];
+            else
+                f1[tid % CHANNEL_STRIDE][k1] = static_cast<scalar_t>(0.0);
+        }
+
+        __syncthreads();
+
+        for (int iy = 0; iy < rd + 1; iy++) {
+            for (int ix = 0; ix < rd + 1; ix++) {
+                for (int k = 0; k < BLOCK_HW; k += BLOCK_HW / CHANNEL_STRIDE) {
+                    int k1 = k + tid / CHANNEL_STRIDE;
+                    int h2 = static_cast<int>(floorf(y2s[k1])) - r + iy;
+                    int w2 = static_cast<int>(floorf(x2s[k1])) - r + ix;
+                    int c2 = c + tid % CHANNEL_STRIDE;
+
+                    if (within_bounds(h2, w2, H2, W2) && c2 < C)
+                        f2[tid % CHANNEL_STRIDE][k1] = fmap2[b][dst][h2][w2][c2];
+                    else
+                        f2[tid % CHANNEL_STRIDE][k1] = static_cast<scalar_t>(0.0);
+                }
+
+                __syncthreads();
+
+                if (valid1) {
+                    float s = 0.0f;
+                    for (int k = 0; k < CHANNEL_STRIDE; k++) {
+                        s += static_cast<float>(f1[k][tid]) * static_cast<float>(f2[k][tid]);
+                    }
+
+                    float *corr_ptr = &corr[b][m][level_offset][h1][w1];
+
+                    if (iy > 0 && ix > 0) *(corr_ptr + ((iy - 1) + rd * (ix - 1)) * H1 * W1) += s * dy * dx;
+
+                    if (iy > 0 && ix < rd) *(corr_ptr + ((iy - 1) + rd * ix) * H1 * W1) += s * dy * (1.0f - dx);
+
+                    if (iy < rd && ix > 0) *(corr_ptr + (iy + rd * (ix - 1)) * H1 * W1) += s * (1.0f - dy) * dx;
+
+                    if (iy < rd && ix < rd) *(corr_ptr + (iy + rd * ix) * H1 * W1) += s * (1.0f - dy) * (1.0f - dx);
+                }
+
+                __syncthreads();
+            }
+        }
+    }
+}
+
+template <typename scalar_t>
 __global__ void altcorr_backward_kernel(
     const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> fmap1,
     const torch::PackedTensorAccessor32<scalar_t, 4, torch::RestrictPtrTraits> fmap2,
@@ -284,6 +386,38 @@ std::vector<torch::Tensor> altcorr_cuda_forward(torch::Tensor fmap1, torch::Tens
                                                 coords.packed_accessor32<float, 5, torch::RestrictPtrTraits>(),
                                                 corr.packed_accessor32<scalar_t, 5, torch::RestrictPtrTraits>(),
                                                 radius);
+                                        }));
+
+    return {corr};
+}
+
+std::vector<torch::Tensor> altcorr_index_cuda_forward(torch::Tensor fmap1, std::vector<torch::Tensor> fmap2_pyramid,
+                                                      torch::Tensor coords, torch::Tensor ii, torch::Tensor jj,
+                                                      int radius) {
+    const auto B = coords.size(0);
+    const auto M = coords.size(1);
+    const auto H = coords.size(2);
+    const auto W = coords.size(3);
+    const auto rd = 2 * radius + 1;
+    const auto L = static_cast<int64_t>(fmap2_pyramid.size());
+
+    auto corr = torch::zeros({B, M, L * rd * rd, H, W}, fmap1.options().dtype(torch::kFloat));
+
+    const dim3 blocks(B * M, (H + BLOCK_H - 1) / BLOCK_H, (W + BLOCK_W - 1) / BLOCK_W);
+    const dim3 threads(BLOCK_H, BLOCK_W);
+
+    AT_DISPATCH_FLOATING_TYPES_AND_HALF(fmap1.scalar_type(), "altcorr_index_forward_kernel", ([&] {
+                                            for (int64_t level = 0; level < L; ++level) {
+                                                altcorr_index_forward_kernel<scalar_t><<<blocks, threads>>>(
+                                                    fmap1.packed_accessor32<scalar_t, 5, torch::RestrictPtrTraits>(),
+                                                    fmap2_pyramid[level].packed_accessor32<scalar_t, 5, torch::RestrictPtrTraits>(),
+                                                    coords.packed_accessor32<float, 5, torch::RestrictPtrTraits>(),
+                                                    ii.packed_accessor32<int64_t, 1, torch::RestrictPtrTraits>(),
+                                                    jj.packed_accessor32<int64_t, 1, torch::RestrictPtrTraits>(),
+                                                    corr.packed_accessor32<float, 5, torch::RestrictPtrTraits>(),
+                                                    radius, static_cast<int>(level * rd * rd),
+                                                    static_cast<float>(1 << level));
+                                            }
                                         }));
 
     return {corr};

--- a/csrc/droid_net_ext/droid.cpp
+++ b/csrc/droid_net_ext/droid.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <torch/extension.h>
+#include <pybind11/stl.h>
 #include <vector>
 
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
@@ -17,6 +18,9 @@ std::vector<torch::Tensor> altcorr_cuda_forward(torch::Tensor fmap1, torch::Tens
                                                 int radius);
 std::vector<torch::Tensor> altcorr_cuda_backward(torch::Tensor fmap1, torch::Tensor fmap2, torch::Tensor coords,
                                                  torch::Tensor corr_grad, int radius);
+std::vector<torch::Tensor> altcorr_index_cuda_forward(torch::Tensor fmap1, std::vector<torch::Tensor> fmap2_pyramid,
+                                                      torch::Tensor coords, torch::Tensor ii, torch::Tensor jj,
+                                                      int radius);
 
 // c++ python binding
 std::vector<torch::Tensor> corr_index_forward(torch::Tensor volume, torch::Tensor coords, int radius) {
@@ -44,6 +48,20 @@ std::vector<torch::Tensor> altcorr_forward(torch::Tensor fmap1, torch::Tensor fm
     return altcorr_cuda_forward(fmap1, fmap2, coords, radius);
 }
 
+std::vector<torch::Tensor> altcorr_index_forward(torch::Tensor fmap1, std::vector<torch::Tensor> fmap2_pyramid,
+                                                 torch::Tensor coords, torch::Tensor ii, torch::Tensor jj,
+                                                 int radius) {
+    CHECK_INPUT(fmap1);
+    CHECK_INPUT(coords);
+    CHECK_INPUT(ii);
+    CHECK_INPUT(jj);
+    for (const auto& fmap2 : fmap2_pyramid) {
+        CHECK_INPUT(fmap2);
+    }
+
+    return altcorr_index_cuda_forward(fmap1, fmap2_pyramid, coords, ii, jj, radius);
+}
+
 std::vector<torch::Tensor> altcorr_backward(torch::Tensor fmap1, torch::Tensor fmap2, torch::Tensor coords,
                                             torch::Tensor corr_grad, int radius) {
     CHECK_INPUT(fmap1);
@@ -57,6 +75,7 @@ std::vector<torch::Tensor> altcorr_backward(torch::Tensor fmap1, torch::Tensor f
 void pybind_droid_net_ext(py::module& m) {
     // correlation volume kernels
     m.def("altcorr_forward", &altcorr_forward, "ALTCORR forward");
+    m.def("altcorr_index_forward", &altcorr_index_forward, "ALTCORR indexed forward");
     m.def("altcorr_backward", &altcorr_backward, "ALTCORR backward");
     m.def("corr_index_forward", &corr_index_forward, "INDEX forward");
     m.def("corr_index_backward", &corr_index_backward, "INDEX backward");

--- a/tests/test_altcorr_indexed.py
+++ b/tests/test_altcorr_indexed.py
@@ -1,0 +1,52 @@
+import unittest
+
+try:
+    import torch
+
+    from vipe.ext import droid_net_ext
+    from vipe.slam.networks.droid_net import AltCorrBlock
+except ImportError:  # pragma: no cover - lets discovery work without the runtime env
+    torch = None
+    droid_net_ext = None
+    AltCorrBlock = None
+
+
+def _has_cuda_droid_ext() -> bool:
+    return torch is not None and torch.cuda.is_available() and droid_net_ext is not None
+
+
+@unittest.skipUnless(_has_cuda_droid_ext(), "CUDA droid extension is required")
+class AltCorrIndexedTest(unittest.TestCase):
+    def setUp(self):
+        torch.manual_seed(2028)
+
+    def test_indexed_altcorr_matches_corr_layer_reference(self):
+        device = torch.device("cuda")
+        batch, n_frames, channels, height, width = 1, 7, 128, 48, 64
+        n_edges = 5
+
+        fmaps = torch.randn(batch, n_frames, channels, height, width, device=device, dtype=torch.float16)
+        yy, xx = torch.meshgrid(
+            torch.arange(height, device=device),
+            torch.arange(width, device=device),
+            indexing="ij",
+        )
+        coords = torch.stack([xx, yy], dim=-1).float()[None].repeat(batch, n_edges, 1, 1, 1)
+        coords = coords + 0.4 * torch.randn_like(coords)
+
+        ii = torch.tensor([0, 1, 2, 3, 4], device=device, dtype=torch.long)
+        jj = torch.tensor([1, 2, 3, 4, 5], device=device, dtype=torch.long)
+        corr = AltCorrBlock(fmaps)
+
+        coords_with_samples = coords.unsqueeze(dim=-2)
+        reference = corr.corr_fn_reference(coords_with_samples, ii, jj)
+        indexed = corr.corr_fn_indexed(coords_with_samples, ii, jj)
+
+        torch.testing.assert_close(indexed, reference, atol=2e-4, rtol=1e-4)
+
+        default = corr(coords, ii, jj)
+        torch.testing.assert_close(default, reference.squeeze(dim=-1), atol=2e-4, rtol=1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vipe/slam/networks/droid_net.py
+++ b/vipe/slam/networks/droid_net.py
@@ -141,7 +141,7 @@ class AltCorrBlock:
             self.pyramid.append(fmap_lvl.view(*sz))
             fmaps = F.avg_pool2d(fmaps, 2, stride=2)
 
-    def corr_fn(self, coords, ii, jj):
+    def corr_fn_reference(self, coords, ii, jj):
         B, N, H, W, S, _ = coords.shape
         coords = coords.permute(0, 1, 4, 2, 3, 5)
 
@@ -161,6 +161,26 @@ class AltCorrBlock:
 
         corr = torch.cat(corr_list, dim=2)
         return corr
+
+    def corr_fn_indexed(self, coords, ii, jj):
+        if coords.shape[-2] != 1:
+            return self.corr_fn_reference(coords, ii, jj)
+
+        coords = coords.squeeze(dim=-2).contiguous()
+        ii = ii.contiguous()
+        jj = jj.contiguous()
+        (corr,) = droid_net_ext.altcorr_index_forward(
+            self.pyramid[0],
+            self.pyramid,
+            coords,
+            ii,
+            jj,
+            self.radius,
+        )
+        return corr.unsqueeze(dim=-1)
+
+    def corr_fn(self, coords, ii, jj):
+        return self.corr_fn_indexed(coords, ii, jj)
 
     def __call__(self, coords, ii, jj):
         squeeze_output = False


### PR DESCRIPTION
## Summary
- add an indexed AltCorr CUDA path that queries selected frame pairs directly
- route `AltCorrBlock.corr_fn` through the indexed path by default, with the existing `CorrLayer.apply` reference path retained for unsupported multi-sample coordinates
- add a CUDA parity test comparing the indexed implementation against the `CorrLayer.apply` reference path

## Tests
- pre-commit: ruff format, ruff check, mypy
- `UV_CACHE_DIR=/tmp/uv-cache CUDA_HOME=/usr/local/cuda-12.8 VIPE_EXT_JIT=1 MAX_JOBS=8 /home/huangjh/.local/bin/uv run python -m unittest tests.test_altcorr_indexed -v`
- `UV_CACHE_DIR=/tmp/uv-cache CUDA_HOME=/usr/local/cuda-12.8 VIPE_EXT_JIT=1 MAX_JOBS=8 /home/huangjh/.local/bin/uv run python -m unittest tests.test_ba_triton_kernels tests.test_ba_fused_terms tests.test_slam_ext_ba_extended tests.test_altcorr_indexed -v`