### PR TITLE
Add fused BA path

### DIFF
--- a/configs/slam/default.yaml
+++ b/configs/slam/default.yaml
@@ -47,6 +47,7 @@ keyframe_depth: metric3d-small
 
 ba:
   dense_disp_alpha: 0.001
+  fused: false
   intrinsics_damping_scale: 1.0
   # robust kernel for dense-flow residual: null (L2) | huber | tukey | gnc_tls
   robust_kernel: null

--- a/csrc/slam_ext/geom_kernels.cu
+++ b/csrc/slam_ext/geom_kernels.cu
@@ -194,6 +194,9 @@ __global__ void projective_transform_kernel(
     torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> Efi,
     torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> Hff,
     torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> vf,
+    torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> flow_energy,
+    const int itr,
+    const bool compute_energy,
     const bool optimize_intrinsics,
     const float intrinsics_scale) {
     const int block_id = blockIdx.x;
@@ -276,6 +279,7 @@ __global__ void projective_transform_kernel(
     float fi[6], fj[6];
     float hf = 0.0f;
     float vfocal = 0.0f;
+    float residual_energy = 0.0f;
 
     int l;
     for (l = 0; l < 12 * (12 + 1) / 2; l++) {
@@ -330,6 +334,7 @@ __global__ void projective_transform_kernel(
         // Residuals
         const float ru = target[block_id][0][i][j] - (fx * d * x + cx);
         const float rv = target[block_id][1][i][j] - (fy * d * y + cy);
+        residual_energy += wu * ru * ru + wv * rv * rv;
 
         // x - coordinate
 
@@ -434,6 +439,16 @@ __global__ void projective_transform_kernel(
     // As we parallel over the pixels using 256 threads, we need to reduce the results.
 
     __shared__ float sdata[THREADS];
+    if (compute_energy) {
+        sdata[threadIdx.x] = residual_energy;
+        blockReduce(sdata);
+        if (threadIdx.x == 0) {
+            flow_energy[itr][block_id] = sdata[0];
+        }
+
+        __syncthreads();
+    }
+
     for (int n = 0; n < 6; n++) {
         sdata[threadIdx.x] = vi[n];
         blockReduce(sdata);
@@ -1614,7 +1629,8 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
                                         torch::Tensor depth_active, const int t0, const int t1, const int iterations,
                                         const float lm, const float ep, const bool motion_only, const float alpha,
                                         const bool optimize_intrinsics, const float intrinsics_lm,
-                                        const float intrinsics_ep, const float intrinsics_scale) {
+                                        const float intrinsics_ep, const float intrinsics_scale,
+                                        const bool compute_energy) {
     CHECK_INPUT(targets);
     CHECK_INPUT(weights);
     CHECK_INPUT(poses);
@@ -1656,6 +1672,8 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
     torch::Tensor Efi = torch::zeros({num, ht * wd}, opts);
     torch::Tensor Hff = torch::zeros({num}, opts);
     torch::Tensor vf = torch::zeros({num}, opts);
+    torch::Tensor energy = torch::empty({compute_energy ? iterations : 0}, opts);
+    torch::Tensor flow_energy = torch::empty({compute_energy ? iterations : 0, num}, opts);
 
     for (int itr = 0; itr < iterations; itr++) {
         projective_transform_kernel<<<num, THREADS>>>(
@@ -1678,7 +1696,9 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
             Fs.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
             Efi.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
             Hff.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
-            vf.packed_accessor32<float, 1, torch::RestrictPtrTraits>(), optimize_intrinsics, intrinsics_scale);
+            vf.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
+            flow_energy.packed_accessor32<float, 2, torch::RestrictPtrTraits>(), itr, compute_energy,
+            optimize_intrinsics, intrinsics_scale);
 
         // pose x pose block
         SparseBlock A(t1 - t0, 6);
@@ -1699,6 +1719,30 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
             A.update_rhs(vs.reshape({-1, 6}), torch::cat({ii, jj}) - t0);
         }
 
+        torch::Tensor active;
+        torch::Tensor m;
+        if (!motion_only) {
+            active = depth_active.index({kx}).to(torch::TensorOptions().dtype(torch::kFloat32)).view({-1, 1});
+            // add depth residual if there are depth sensor measurements
+            // m = (disps_sens[kx] > 0).float().view(-1, ht*wd)
+            m = (disps_sens.index({kx, "..."}) > 0)
+                    .to(torch::TensorOptions().dtype(torch::kFloat32))
+                    .view({-1, ht * wd}) *
+                active;
+        }
+
+        if (compute_energy) {
+            torch::Tensor iter_energy = flow_energy.index({itr}).sum();
+            if (!motion_only) {
+                iter_energy =
+                    iter_energy +
+                    (m * alpha *
+                     torch::pow((disps.index({kx, "..."}) - disps_sens.index({kx, "..."})).view({-1, ht * wd}), 2))
+                        .sum();
+            }
+            energy.index_put_({itr}, iter_energy);
+        }
+
         if (motion_only) {
             double df = 0.0;
             if (optimize_intrinsics) {
@@ -1717,13 +1761,6 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
         }
 
         else {
-            torch::Tensor active = depth_active.index({kx}).to(torch::TensorOptions().dtype(torch::kFloat32)).view({-1, 1});
-            // add depth residual if there are depth sensor measurements
-            // m = (disps_sens[kx] > 0).float().view(-1, ht*wd)
-            torch::Tensor m = (disps_sens.index({kx, "..."}) > 0)
-                                  .to(torch::TensorOptions().dtype(torch::kFloat32))
-                                  .view({-1, ht * wd}) *
-                              active;
             // LHS: C = C[kx] + eta + alpha (if disps_sens exists)
             torch::Tensor C =
                 active * (accum_cuda(Cii, ii, kx) + eta.view({-1, ht * wd}) + m * alpha) + (1 - active);
@@ -1783,7 +1820,7 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
         }
     }
 
-    return {dx, dz};
+    return {dx, dz, energy};
 }
 
 std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
@@ -1793,7 +1830,7 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
                                    const float alpha) {
     torch::Tensor depth_active = torch::ones({disps.size(0)}, disps.options());
     return ba_cuda_impl(poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj, depth_active, t0, t1,
-                        iterations, lm, ep, motion_only, alpha, false, 1e-6f, 1e-6f, 1.0f);
+                        iterations, lm, ep, motion_only, alpha, false, 1e-6f, 1e-6f, 1.0f, false);
 }
 
 std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
@@ -1803,10 +1840,10 @@ std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor d
                                             const int iterations, const float lm, const float ep,
                                             const bool motion_only, const float alpha, const bool optimize_intrinsics,
                                             const float intrinsics_lm, const float intrinsics_ep,
-                                            const float intrinsics_scale) {
+                                            const float intrinsics_scale, const bool compute_energy) {
     return ba_cuda_impl(poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj, depth_active, t0, t1,
                         iterations, lm, ep, motion_only, alpha, optimize_intrinsics, intrinsics_lm, intrinsics_ep,
-                        intrinsics_scale);
+                        intrinsics_scale, compute_energy);
 }
 
 torch::Tensor frame_distance_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics, torch::Tensor pi,

--- a/csrc/slam_ext/geom_kernels.cu
+++ b/csrc/slam_ext/geom_kernels.cu
@@ -181,6 +181,7 @@ __global__ void projective_transform_kernel(
     const torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> poses,
     const torch::PackedTensorAccessor32<float, 3, torch::RestrictPtrTraits> disps,
     const torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> intrinsics,
+    const torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> depth_active,
     const torch::PackedTensorAccessor32<long, 1, torch::RestrictPtrTraits> ii,
     const torch::PackedTensorAccessor32<long, 1, torch::RestrictPtrTraits> jj,
     torch::PackedTensorAccessor32<float, 4, torch::RestrictPtrTraits> Hs,
@@ -188,7 +189,13 @@ __global__ void projective_transform_kernel(
     torch::PackedTensorAccessor32<float, 3, torch::RestrictPtrTraits> Eii,
     torch::PackedTensorAccessor32<float, 3, torch::RestrictPtrTraits> Eij,
     torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> Cii,
-    torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> bz) {
+    torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> bz,
+    torch::PackedTensorAccessor32<float, 3, torch::RestrictPtrTraits> Fs,
+    torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> Efi,
+    torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> Hff,
+    torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> vf,
+    const bool optimize_intrinsics,
+    const float intrinsics_scale) {
     const int block_id = blockIdx.x;
     const int thread_id = threadIdx.x;
 
@@ -197,6 +204,7 @@ __global__ void projective_transform_kernel(
 
     int ix = static_cast<int>(ii[block_id]);
     int jx = static_cast<int>(jj[block_id]);
+    const float active_depth = depth_active[ix];
 
     __shared__ float fx;
     __shared__ float fy;
@@ -265,6 +273,9 @@ __global__ void projective_transform_kernel(
     float hij[12 * (12 + 1) / 2];
 
     float vi[6], vj[6];
+    float fi[6], fj[6];
+    float hf = 0.0f;
+    float vfocal = 0.0f;
 
     int l;
     for (l = 0; l < 12 * (12 + 1) / 2; l++) {
@@ -274,6 +285,8 @@ __global__ void projective_transform_kernel(
     for (int n = 0; n < 6; n++) {
         vi[n] = 0;
         vj[n] = 0;
+        fi[n] = 0;
+        fj[n] = 0;
     }
 
     __syncthreads();
@@ -304,6 +317,16 @@ __global__ void projective_transform_kernel(
         float wu = (Xj[2] < MIN_DEPTH) ? 0.0 : .001 * weight[block_id][0][i][j];
         float wv = (Xj[2] < MIN_DEPTH) ? 0.0 : .001 * weight[block_id][1][i][j];
 
+        float Jf_u = 0.0f;
+        float Jf_v = 0.0f;
+        if (optimize_intrinsics) {
+            float dXi_df[4] = {-Xi[0] / fx, -Xi[1] / fy, 0.0f, 0.0f};
+            float dXj_df[4];
+            actSE3(tij, qij, dXi_df, dXj_df);
+            Jf_u = intrinsics_scale * (fx * d * dXj_df[0] - fx * x * d2 * dXj_df[2] + x * d);
+            Jf_v = intrinsics_scale * (fy * d * dXj_df[1] - fy * y * d2 * dXj_df[2] + y * d);
+        }
+
         // Residuals
         const float ru = target[block_id][0][i][j] - (fx * d * x + cx);
         const float rv = target[block_id][1][i][j] - (fy * d * y + cy);
@@ -322,8 +345,10 @@ __global__ void projective_transform_kernel(
         Jz = fx * (tij[0] * d - tij[2] * (x * d2));
 
         // LHS and RHS of depth!
-        Cii[block_id][k] = wu * Jz * Jz;
-        bz[block_id][k] = wu * ru * Jz;
+        const float wu_depth = wu * active_depth;
+        Cii[block_id][k] = wu_depth * Jz * Jz;
+        bz[block_id][k] = wu_depth * ru * Jz;
+        if (optimize_intrinsics) Efi[block_id][k] = wu_depth * Jz * Jf_u;
 
         // If stereo don't add related terms.
         if (ix == jx) wu = 0;
@@ -345,10 +370,18 @@ __global__ void projective_transform_kernel(
         for (int n = 0; n < 6; n++) {
             vi[n] += wu * ru * Ji[n];
             vj[n] += wu * ru * Jj[n];
+            if (optimize_intrinsics) {
+                fi[n] += wu * Ji[n] * Jf_u;
+                fj[n] += wu * Jj[n] * Jf_u;
+            }
 
             // block_id is the edge idx, k is pixel idx
-            Eii[block_id][n][k] = wu * Jz * Ji[n];
-            Eij[block_id][n][k] = wu * Jz * Jj[n];
+            Eii[block_id][n][k] = wu_depth * Jz * Ji[n];
+            Eij[block_id][n][k] = wu_depth * Jz * Jj[n];
+        }
+        if (optimize_intrinsics) {
+            hf += wu * Jf_u * Jf_u;
+            vfocal += wu * ru * Jf_u;
         }
 
         // y - coordinate
@@ -361,8 +394,10 @@ __global__ void projective_transform_kernel(
         Jj[5] = fy * (x * d);
 
         Jz = fy * (tij[1] * d - tij[2] * (y * d2));
-        Cii[block_id][k] += wv * Jz * Jz;
-        bz[block_id][k] += wv * rv * Jz;
+        const float wv_depth = wv * active_depth;
+        Cii[block_id][k] += wv_depth * Jz * Jz;
+        bz[block_id][k] += wv_depth * rv * Jz;
+        if (optimize_intrinsics) Efi[block_id][k] += wv_depth * Jz * Jf_v;
 
         if (ix == jx) wv = 0;
 
@@ -380,9 +415,17 @@ __global__ void projective_transform_kernel(
         for (int n = 0; n < 6; n++) {
             vi[n] += wv * rv * Ji[n];
             vj[n] += wv * rv * Jj[n];
+            if (optimize_intrinsics) {
+                fi[n] += wv * Ji[n] * Jf_v;
+                fj[n] += wv * Jj[n] * Jf_v;
+            }
 
-            Eii[block_id][n][k] += wv * Jz * Ji[n];
-            Eij[block_id][n][k] += wv * Jz * Jj[n];
+            Eii[block_id][n][k] += wv_depth * Jz * Ji[n];
+            Eij[block_id][n][k] += wv_depth * Jz * Jj[n];
+        }
+        if (optimize_intrinsics) {
+            hf += wv * Jf_v * Jf_v;
+            vfocal += wv * rv * Jf_v;
         }
     }
 
@@ -404,6 +447,40 @@ __global__ void projective_transform_kernel(
         blockReduce(sdata);
         if (threadIdx.x == 0) {
             vs[1][block_id][n] = sdata[0];
+        }
+
+        if (optimize_intrinsics) {
+            __syncthreads();
+
+            sdata[threadIdx.x] = fi[n];
+            blockReduce(sdata);
+            if (threadIdx.x == 0) {
+                Fs[0][block_id][n] = sdata[0];
+            }
+
+            __syncthreads();
+
+            sdata[threadIdx.x] = fj[n];
+            blockReduce(sdata);
+            if (threadIdx.x == 0) {
+                Fs[1][block_id][n] = sdata[0];
+            }
+        }
+    }
+
+    if (optimize_intrinsics) {
+        sdata[threadIdx.x] = hf;
+        blockReduce(sdata);
+        if (threadIdx.x == 0) {
+            Hff[block_id] = sdata[0];
+        }
+
+        __syncthreads();
+
+        sdata[threadIdx.x] = vfocal;
+        blockReduce(sdata);
+        if (threadIdx.x == 0) {
+            vf[block_id] = sdata[0];
         }
     }
 
@@ -943,6 +1020,11 @@ __global__ void disp_retr_kernel(torch::PackedTensorAccessor32<float, 3, torch::
     }
 }
 
+__global__ void intrinsics_retr_kernel(torch::PackedTensorAccessor32<float, 1, torch::RestrictPtrTraits> intrinsics,
+                                       const float df_scaled) {
+    if (threadIdx.x < 2) intrinsics[threadIdx.x] += df_scaled;
+}
+
 torch::Tensor accum_cuda(torch::Tensor data, torch::Tensor ix, torch::Tensor jx) {
     torch::Tensor ix_cpu = ix.to(torch::kCPU);
     torch::Tensor jx_cpu = jx.to(torch::kCPU);
@@ -1195,6 +1277,137 @@ class SparseBlock {
     const int M;
 };
 
+class SparseSystem {
+   public:
+    Eigen::SparseMatrix<double> A;
+    Eigen::VectorXd b;
+
+    SparseSystem(int pose_count, int scalar_count = 0)
+        : pose_count(pose_count), scalar_count(scalar_count), dim(6 * pose_count + scalar_count) {
+        A = Eigen::SparseMatrix<double>(dim, dim);
+        b = Eigen::VectorXd::Zero(dim);
+    }
+
+    SparseSystem(Eigen::SparseMatrix<double> const &A, Eigen::VectorX<double> const &b, int pose_count,
+                 int scalar_count)
+        : A(A), b(b), pose_count(pose_count), scalar_count(scalar_count), dim(6 * pose_count + scalar_count) {}
+
+    void add_lhs_pose_blocks(torch::Tensor As, torch::Tensor ii, torch::Tensor jj) {
+        auto As_cpu = As.to(torch::kCPU).to(torch::kFloat64);
+        auto ii_cpu = ii.to(torch::kCPU).to(torch::kInt64);
+        auto jj_cpu = jj.to(torch::kCPU).to(torch::kInt64);
+
+        auto As_acc = As_cpu.accessor<double, 3>();
+        auto ii_acc = ii_cpu.accessor<long, 1>();
+        auto jj_acc = jj_cpu.accessor<long, 1>();
+
+        for (int n = 0; n < ii_cpu.size(0); n++) {
+            const int i = ii_acc[n];
+            const int j = jj_acc[n];
+
+            if (i >= 0 && i < pose_count && j >= 0 && j < pose_count) {
+                for (int k = 0; k < 6; k++) {
+                    for (int l = 0; l < 6; l++) {
+                        const double val = As_acc[n][k][l];
+                        triplet_list.push_back(T(6 * i + k, 6 * j + l, val));
+                    }
+                }
+            }
+        }
+    }
+
+    void add_rhs_pose_blocks(torch::Tensor bs, torch::Tensor ii) {
+        auto bs_cpu = bs.to(torch::kCPU).to(torch::kFloat64);
+        auto ii_cpu = ii.to(torch::kCPU).to(torch::kInt64);
+
+        auto bs_acc = bs_cpu.accessor<double, 2>();
+        auto ii_acc = ii_cpu.accessor<long, 1>();
+
+        for (int n = 0; n < ii_cpu.size(0); n++) {
+            const int i = ii_acc[n];
+            if (i >= 0 && i < pose_count) {
+                for (int j = 0; j < 6; j++) {
+                    b(6 * i + j) += bs_acc[n][j];
+                }
+            }
+        }
+    }
+
+    void add_lhs_pose_scalar(torch::Tensor As, torch::Tensor ii) {
+        if (scalar_count == 0) return;
+
+        auto As_cpu = As.to(torch::kCPU).to(torch::kFloat64);
+        auto ii_cpu = ii.to(torch::kCPU).to(torch::kInt64);
+
+        auto As_acc = As_cpu.accessor<double, 2>();
+        auto ii_acc = ii_cpu.accessor<long, 1>();
+        const int scalar_col = 6 * pose_count;
+
+        for (int n = 0; n < ii_cpu.size(0); n++) {
+            const int i = ii_acc[n];
+            if (i >= 0 && i < pose_count) {
+                for (int j = 0; j < 6; j++) {
+                    const double val = As_acc[n][j];
+                    triplet_list.push_back(T(6 * i + j, scalar_col, val));
+                    triplet_list.push_back(T(scalar_col, 6 * i + j, val));
+                }
+            }
+        }
+    }
+
+    void add_lhs_scalar(double val) {
+        if (scalar_count == 0) return;
+        triplet_list.push_back(T(6 * pose_count, 6 * pose_count, val));
+    }
+
+    void add_rhs_scalar(double val) {
+        if (scalar_count == 0) return;
+        b(6 * pose_count) += val;
+    }
+
+    void finalize() { A.setFromTriplets(triplet_list.begin(), triplet_list.end()); }
+
+    SparseSystem operator-(const SparseSystem &S) const {
+        return SparseSystem(A - S.A, b - S.b, pose_count, scalar_count);
+    }
+
+    std::tuple<torch::Tensor, double> solve(const float pose_lm, const float pose_ep, const float scalar_lm,
+                                            const float scalar_ep) {
+        torch::Tensor dx;
+        double df = 0.0;
+
+        Eigen::SparseMatrix<double> L(A);
+        for (int i = 0; i < dim; i++) {
+            const bool is_scalar = i >= 6 * pose_count;
+            const double lm = is_scalar ? scalar_lm : pose_lm;
+            const double ep = is_scalar ? scalar_ep : pose_ep;
+            const double diag = L.coeff(i, i);
+            L.coeffRef(i, i) += ep + lm * diag;
+        }
+
+        Eigen::SimplicialLLT<Eigen::SparseMatrix<double>> solver;
+        solver.compute(L);
+
+        if (solver.info() == Eigen::Success) {
+            Eigen::VectorXd x = solver.solve(b);
+            dx = torch::from_blob(x.data(), {pose_count, 6}, torch::TensorOptions().dtype(torch::kFloat64))
+                     .to(torch::kCUDA)
+                     .to(torch::kFloat32);
+            if (scalar_count > 0) df = x(6 * pose_count);
+        } else {
+            dx = torch::zeros({pose_count, 6}, torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32));
+        }
+
+        return std::make_tuple(dx, df);
+    }
+
+   private:
+    const int pose_count;
+    const int scalar_count;
+    const int dim;
+    std::vector<T> triplet_list;
+};
+
 SparseBlock schur_block(torch::Tensor E, torch::Tensor Q, torch::Tensor w, torch::Tensor ii, torch::Tensor jj,
                         torch::Tensor kk, const int t0, const int t1) {
     torch::Tensor ii_cpu = ii.to(torch::kCPU);
@@ -1213,7 +1426,7 @@ SparseBlock schur_block(torch::Tensor E, torch::Tensor Q, torch::Tensor w, torch
         const int j = jj_data[n];
         const int k = kk_data[n];
 
-        if (j >= t0 && j <= t1) {
+        if (j >= t0 && j < t1) {
             const int t = j - t0;
             graph[t].push_back(k);
             index[t].push_back(n);
@@ -1280,10 +1493,128 @@ SparseBlock schur_block(torch::Tensor E, torch::Tensor Q, torch::Tensor w, torch
     return A;
 }
 
-std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
-                                   torch::Tensor disps_sens, torch::Tensor targets, torch::Tensor weights,
-                                   torch::Tensor eta, torch::Tensor ii, torch::Tensor jj, const int t0, const int t1,
-                                   const int iterations, const float lm, const float ep, const bool motion_only) {
+SparseSystem schur_system_with_intrinsics(torch::Tensor E, torch::Tensor Ef, torch::Tensor Q, torch::Tensor w,
+                                          torch::Tensor ii, torch::Tensor jj, torch::Tensor kk, const int t0,
+                                          const int t1) {
+    torch::Tensor ii_cpu = ii.to(torch::kCPU);
+    torch::Tensor jj_cpu = jj.to(torch::kCPU);
+    torch::Tensor kk_cpu = kk.to(torch::kCPU);
+
+    const int P = t1 - t0;
+    const long *jj_data = jj_cpu.data_ptr<long>();
+    const long *kk_data = kk_cpu.data_ptr<long>();
+
+    std::vector<std::vector<long>> graph(P);
+    std::vector<std::vector<long>> index(P);
+    std::vector<long> row_list, pose_list, depth_list;
+
+    for (int n = 0; n < jj_cpu.size(0); n++) {
+        const int j = jj_data[n];
+        const int k = kk_data[n];
+
+        if (j >= t0 && j < t1) {
+            const int t = j - t0;
+            graph[t].push_back(k);
+            index[t].push_back(n);
+
+            row_list.push_back(n);
+            pose_list.push_back(t);
+            depth_list.push_back(k);
+        }
+    }
+
+    std::vector<long> ii_list, jj_list, idx;
+
+    for (int i = 0; i < P; i++) {
+        for (int j = 0; j < P; j++) {
+            for (int k = 0; k < graph[i].size(); k++) {
+                for (int l = 0; l < graph[j].size(); l++) {
+                    if (graph[i][k] == graph[j][l]) {
+                        ii_list.push_back(i);
+                        jj_list.push_back(j);
+
+                        idx.push_back(index[i][k]);
+                        idx.push_back(index[j][l]);
+                        idx.push_back(graph[i][k]);
+                    }
+                }
+            }
+        }
+    }
+
+    SparseSystem S(P, 1);
+
+    if (!idx.empty()) {
+        torch::Tensor ix_cuda =
+            torch::from_blob(idx.data(), {long(idx.size())}, torch::TensorOptions().dtype(torch::kInt64))
+                .to(torch::kCUDA)
+                .view({-1, 3});
+
+        torch::Tensor ii2_cpu =
+            torch::from_blob(ii_list.data(), {long(ii_list.size())}, torch::TensorOptions().dtype(torch::kInt64))
+                .view({-1});
+
+        torch::Tensor jj2_cpu =
+            torch::from_blob(jj_list.data(), {long(jj_list.size())}, torch::TensorOptions().dtype(torch::kInt64))
+                .view({-1});
+
+        torch::Tensor Spp =
+            torch::zeros({ix_cuda.size(0), 6, 6}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+
+        EEt6x6_kernel<<<ix_cuda.size(0), THREADS>>>(E.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
+                                                    Q.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
+                                                    ix_cuda.packed_accessor32<long, 2, torch::RestrictPtrTraits>(),
+                                                    Spp.packed_accessor32<float, 3, torch::RestrictPtrTraits>());
+
+        S.add_lhs_pose_blocks(Spp, ii2_cpu, jj2_cpu);
+    }
+
+    torch::Tensor jx_cuda = torch::stack({kk_cpu}, -1).to(torch::kCUDA).to(torch::kInt64);
+    torch::Tensor v =
+        torch::zeros({jx_cuda.size(0), 6}, torch::TensorOptions().dtype(torch::kFloat32).device(torch::kCUDA));
+
+    if (jx_cuda.size(0) > 0) {
+        Ev6x1_kernel<<<jx_cuda.size(0), THREADS>>>(E.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
+                                                   Q.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
+                                                   w.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
+                                                   jx_cuda.packed_accessor32<long, 2, torch::RestrictPtrTraits>(),
+                                                   v.packed_accessor32<float, 2, torch::RestrictPtrTraits>());
+
+        S.add_rhs_pose_blocks(v, jj_cpu - t0);
+    }
+
+    if (!row_list.empty()) {
+        torch::Tensor rows_cuda =
+            torch::from_blob(row_list.data(), {long(row_list.size())}, torch::TensorOptions().dtype(torch::kInt64))
+                .to(torch::kCUDA);
+        torch::Tensor depth_cuda =
+            torch::from_blob(depth_list.data(), {long(depth_list.size())}, torch::TensorOptions().dtype(torch::kInt64))
+                .to(torch::kCUDA);
+        torch::Tensor pose_cpu =
+            torch::from_blob(pose_list.data(), {long(pose_list.size())}, torch::TensorOptions().dtype(torch::kInt64))
+                .view({-1});
+
+        torch::Tensor E_rows = E.index_select(0, rows_cuda);
+        torch::Tensor Q_rows = Q.index_select(0, depth_cuda);
+        torch::Tensor Ef_rows = Ef.index_select(0, depth_cuda);
+        torch::Tensor Spf = (E_rows * (Q_rows * Ef_rows).unsqueeze(1)).sum(2);
+        S.add_lhs_pose_scalar(Spf, pose_cpu);
+    }
+
+    S.add_lhs_scalar((Ef * Q * Ef).sum().item<double>());
+    S.add_rhs_scalar((Ef * Q * w).sum().item<double>());
+    S.finalize();
+
+    return S;
+}
+
+std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
+                                        torch::Tensor disps_sens, torch::Tensor targets, torch::Tensor weights,
+                                        torch::Tensor eta, torch::Tensor ii, torch::Tensor jj,
+                                        torch::Tensor depth_active, const int t0, const int t1, const int iterations,
+                                        const float lm, const float ep, const bool motion_only, const float alpha,
+                                        const bool optimize_intrinsics, const float intrinsics_lm,
+                                        const float intrinsics_ep, const float intrinsics_scale) {
     CHECK_INPUT(targets);
     CHECK_INPUT(weights);
     CHECK_INPUT(poses);
@@ -1292,6 +1623,7 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
     CHECK_INPUT(disps_sens);
     CHECK_INPUT(ii);
     CHECK_INPUT(jj);
+    CHECK_INPUT(depth_active);
 
     auto opts = poses.options();
     const int num = ii.size(0);
@@ -1320,6 +1652,10 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
     torch::Tensor Cii = torch::zeros({num, ht * wd}, opts);
     // RHS of depth
     torch::Tensor wi = torch::zeros({num, ht * wd}, opts);
+    torch::Tensor Fs = torch::zeros({2, num, 6}, opts);
+    torch::Tensor Efi = torch::zeros({num, ht * wd}, opts);
+    torch::Tensor Hff = torch::zeros({num}, opts);
+    torch::Tensor vf = torch::zeros({num}, opts);
 
     for (int itr = 0; itr < iterations; itr++) {
         projective_transform_kernel<<<num, THREADS>>>(
@@ -1329,6 +1665,7 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
             poses.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
             disps.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
             intrinsics.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
+            depth_active.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
             ii.packed_accessor32<long, 1, torch::RestrictPtrTraits>(),
             jj.packed_accessor32<long, 1, torch::RestrictPtrTraits>(),
             // Outputs
@@ -1337,45 +1674,84 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
             Eii.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
             Eij.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
             Cii.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
-            wi.packed_accessor32<float, 2, torch::RestrictPtrTraits>());
+            wi.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
+            Fs.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
+            Efi.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
+            Hff.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
+            vf.packed_accessor32<float, 1, torch::RestrictPtrTraits>(), optimize_intrinsics, intrinsics_scale);
 
         // pose x pose block
         SparseBlock A(t1 - t0, 6);
+        SparseSystem A_ext(t1 - t0, 1);
 
-        A.update_lhs(Hs.reshape({-1, 6, 6}), torch::cat({ii, ii, jj, jj}) - t0, torch::cat({ii, jj, ii, jj}) - t0);
+        if (optimize_intrinsics) {
+            A_ext.add_lhs_pose_blocks(Hs.reshape({-1, 6, 6}), torch::cat({ii, ii, jj, jj}) - t0,
+                                      torch::cat({ii, jj, ii, jj}) - t0);
+            A_ext.add_rhs_pose_blocks(vs.reshape({-1, 6}), torch::cat({ii, jj}) - t0);
+            A_ext.add_lhs_pose_scalar(Fs.reshape({-1, 6}), torch::cat({ii, jj}) - t0);
+            A_ext.add_lhs_scalar(Hff.sum().item<double>());
+            A_ext.add_rhs_scalar(vf.sum().item<double>());
+            A_ext.finalize();
+        } else {
+            A.update_lhs(Hs.reshape({-1, 6, 6}), torch::cat({ii, ii, jj, jj}) - t0,
+                         torch::cat({ii, jj, ii, jj}) - t0);
 
-        A.update_rhs(vs.reshape({-1, 6}), torch::cat({ii, jj}) - t0);
+            A.update_rhs(vs.reshape({-1, 6}), torch::cat({ii, jj}) - t0);
+        }
 
         if (motion_only) {
-            dx = A.solve(lm, ep);
+            double df = 0.0;
+            if (optimize_intrinsics) {
+                std::tie(dx, df) = A_ext.solve(lm, ep, intrinsics_lm, intrinsics_ep);
+            } else {
+                dx = A.solve(lm, ep);
+            }
 
             // update poses
             pose_retr_kernel<<<1, THREADS>>>(poses.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
                                              dx.packed_accessor32<float, 2, torch::RestrictPtrTraits>(), t0, t1);
+            if (optimize_intrinsics) {
+                intrinsics_retr_kernel<<<1, THREADS>>>(
+                    intrinsics.packed_accessor32<float, 1, torch::RestrictPtrTraits>(), df * intrinsics_scale);
+            }
         }
 
         else {
+            torch::Tensor active = depth_active.index({kx}).to(torch::TensorOptions().dtype(torch::kFloat32)).view({-1, 1});
             // add depth residual if there are depth sensor measurements
-            const float alpha = 0.05;
             // m = (disps_sens[kx] > 0).float().view(-1, ht*wd)
             torch::Tensor m = (disps_sens.index({kx, "..."}) > 0)
                                   .to(torch::TensorOptions().dtype(torch::kFloat32))
-                                  .view({-1, ht * wd});
-            // LHS: C = C[kx] + alpha (if disps_sens exists) / eta (otherwise)
-            torch::Tensor C = accum_cuda(Cii, ii, kx) + m * alpha + (1 - m) * eta.view({-1, ht * wd});
+                                  .view({-1, ht * wd}) *
+                              active;
+            // LHS: C = C[kx] + eta + alpha (if disps_sens exists)
+            torch::Tensor C =
+                active * (accum_cuda(Cii, ii, kx) + eta.view({-1, ht * wd}) + m * alpha) + (1 - active);
             // RHS: w = w[kx] - alpha * (disps - disps_sens) (residual)
             torch::Tensor w =
-                accum_cuda(wi, ii, kx) -
-                m * alpha * (disps.index({kx, "..."}) - disps_sens.index({kx, "..."})).view({-1, ht * wd});
+                active *
+                (accum_cuda(wi, ii, kx) -
+                 m * alpha * (disps.index({kx, "..."}) - disps_sens.index({kx, "..."})).view({-1, ht * wd}));
             torch::Tensor Q = 1.0 / C;
 
             // Compute Real-E (JTJ of pose-depth)
             torch::Tensor Ei = accum_cuda(Eii.view({num, 6 * ht * wd}), ii, ts).view({t1 - t0, 6, ht * wd});
             torch::Tensor E = torch::cat({Ei, Eij}, 0);
+            torch::Tensor row_active =
+                depth_active.index({ii_exp}).to(torch::TensorOptions().dtype(torch::kFloat32)).view({-1, 1, 1});
+            E = E * row_active;
 
             // (A - E Q E^T) dx = v - E (Q) w
-            SparseBlock S = schur_block(E, Q, w, ii_exp, jj_exp, kk_exp, t0, t1);
-            dx = (A - S).solve(lm, ep);
+            double df = 0.0;
+            torch::Tensor Ef;
+            if (optimize_intrinsics) {
+                Ef = accum_cuda(Efi, ii, kx) * active;
+                SparseSystem S = schur_system_with_intrinsics(E, Ef, Q, w, ii_exp, jj_exp, kk_exp, t0, t1);
+                std::tie(dx, df) = (A_ext - S).solve(lm, ep, intrinsics_lm, intrinsics_ep);
+            } else {
+                SparseBlock S = schur_block(E, Q, w, ii_exp, jj_exp, kk_exp, t0, t1);
+                dx = (A - S).solve(lm, ep);
+            }
 
             torch::Tensor ix = jj_exp - t0;
 
@@ -1388,10 +1764,17 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
 
             // dz = (1.0/C) * (w - E^T dx)
             dz = Q * (w - accum_cuda(dw, ii_exp, kx));
+            if (optimize_intrinsics) {
+                dz = dz - Q * Ef * df;
+            }
 
             // update poses
             pose_retr_kernel<<<1, THREADS>>>(poses.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
                                              dx.packed_accessor32<float, 2, torch::RestrictPtrTraits>(), t0, t1);
+            if (optimize_intrinsics) {
+                intrinsics_retr_kernel<<<1, THREADS>>>(
+                    intrinsics.packed_accessor32<float, 1, torch::RestrictPtrTraits>(), df * intrinsics_scale);
+            }
 
             // update disparity maps
             disp_retr_kernel<<<kx.size(0), THREADS>>>(disps.packed_accessor32<float, 3, torch::RestrictPtrTraits>(),
@@ -1401,6 +1784,29 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
     }
 
     return {dx, dz};
+}
+
+std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
+                                   torch::Tensor disps_sens, torch::Tensor targets, torch::Tensor weights,
+                                   torch::Tensor eta, torch::Tensor ii, torch::Tensor jj, const int t0, const int t1,
+                                   const int iterations, const float lm, const float ep, const bool motion_only,
+                                   const float alpha) {
+    torch::Tensor depth_active = torch::ones({disps.size(0)}, disps.options());
+    return ba_cuda_impl(poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj, depth_active, t0, t1,
+                        iterations, lm, ep, motion_only, alpha, false, 1e-6f, 1e-6f, 1.0f);
+}
+
+std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
+                                            torch::Tensor disps_sens, torch::Tensor targets, torch::Tensor weights,
+                                            torch::Tensor eta, torch::Tensor ii, torch::Tensor jj,
+                                            torch::Tensor depth_active, const int t0, const int t1,
+                                            const int iterations, const float lm, const float ep,
+                                            const bool motion_only, const float alpha, const bool optimize_intrinsics,
+                                            const float intrinsics_lm, const float intrinsics_ep,
+                                            const float intrinsics_scale) {
+    return ba_cuda_impl(poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj, depth_active, t0, t1,
+                        iterations, lm, ep, motion_only, alpha, optimize_intrinsics, intrinsics_lm, intrinsics_ep,
+                        intrinsics_scale);
 }
 
 torch::Tensor frame_distance_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics, torch::Tensor pi,

--- a/csrc/slam_ext/slam.cpp
+++ b/csrc/slam_ext/slam.cpp
@@ -34,7 +34,7 @@ std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor d
                                             const int iterations, const float lm, const float ep,
                                             const bool motion_only, const float alpha, const bool optimize_intrinsics,
                                             const float intrinsics_lm, const float intrinsics_ep,
-                                            const float intrinsics_scale);
+                                            const float intrinsics_scale, const bool compute_energy);
 
 }  // namespace slam_ext
 
@@ -48,7 +48,7 @@ void pybind_slam_ext(py::module &m) {
           py::arg("weights"), py::arg("eta"), py::arg("ii"), py::arg("jj"), py::arg("depth_active"), py::arg("t0"),
           py::arg("t1"), py::arg("iterations"), py::arg("lm"), py::arg("ep"), py::arg("motion_only"),
           py::arg("alpha"), py::arg("optimize_intrinsics"), py::arg("intrinsics_lm"), py::arg("intrinsics_ep"),
-          py::arg("intrinsics_scale"));
+          py::arg("intrinsics_scale"), py::arg("compute_energy") = false);
     m.def("frame_distance", &slam_ext::frame_distance_cuda, "frame_distance");
     m.def("projmap", &slam_ext::projmap_cuda, "projmap");
     m.def("depth_filter", &slam_ext::depth_filter_cuda, "depth_filter");

--- a/csrc/slam_ext/slam.cpp
+++ b/csrc/slam_ext/slam.cpp
@@ -24,12 +24,31 @@ torch::Tensor iproj_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor
 std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
                                    torch::Tensor disps_sens, torch::Tensor targets, torch::Tensor weights,
                                    torch::Tensor eta, torch::Tensor ii, torch::Tensor jj, const int t0, const int t1,
-                                   const int iterations, const float lm, const float ep, const bool motion_only);
+                                   const int iterations, const float lm, const float ep, const bool motion_only,
+                                   const float alpha);
+
+std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
+                                            torch::Tensor disps_sens, torch::Tensor targets, torch::Tensor weights,
+                                            torch::Tensor eta, torch::Tensor ii, torch::Tensor jj,
+                                            torch::Tensor depth_active, const int t0, const int t1,
+                                            const int iterations, const float lm, const float ep,
+                                            const bool motion_only, const float alpha, const bool optimize_intrinsics,
+                                            const float intrinsics_lm, const float intrinsics_ep,
+                                            const float intrinsics_scale);
 
 }  // namespace slam_ext
 
 void pybind_slam_ext(py::module &m) {
-    m.def("ba", &slam_ext::ba_cuda, "bundle adjustment");
+    m.def("ba", &slam_ext::ba_cuda, "bundle adjustment", py::arg("poses"), py::arg("disps"), py::arg("intrinsics"),
+          py::arg("disps_sens"), py::arg("targets"), py::arg("weights"), py::arg("eta"), py::arg("ii"),
+          py::arg("jj"), py::arg("t0"), py::arg("t1"), py::arg("iterations"), py::arg("lm"), py::arg("ep"),
+          py::arg("motion_only"), py::arg("alpha") = 0.05f);
+    m.def("ba_extended", &slam_ext::ba_extended_cuda, "bundle adjustment with ViPE optional variables",
+          py::arg("poses"), py::arg("disps"), py::arg("intrinsics"), py::arg("disps_sens"), py::arg("targets"),
+          py::arg("weights"), py::arg("eta"), py::arg("ii"), py::arg("jj"), py::arg("depth_active"), py::arg("t0"),
+          py::arg("t1"), py::arg("iterations"), py::arg("lm"), py::arg("ep"), py::arg("motion_only"),
+          py::arg("alpha"), py::arg("optimize_intrinsics"), py::arg("intrinsics_lm"), py::arg("intrinsics_ep"),
+          py::arg("intrinsics_scale"));
     m.def("frame_distance", &slam_ext::frame_distance_cuda, "frame_distance");
     m.def("projmap", &slam_ext::projmap_cuda, "projmap");
     m.def("depth_filter", &slam_ext::depth_filter_cuda, "depth_filter");

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -220,7 +220,7 @@ Bundle-adjustment solver and robust loss options.
 | Field | Type | Default | Constraints | Description |
 | --- | --- | --- | --- | --- |
 | `dense_disp_alpha` | float | required | >= 0.0 | Weight for dense-disparity regularization during bundle adjustment. |
-| `fused` | bool | required | - | Use the fused CUDA bundle-adjustment path when the graph layout is supported. |
+| `fused` | bool | required | - | Use the fused CUDA bundle-adjustment path; unsupported layouts raise an error. |
 | `intrinsics_damping_scale` | float | required | > 0.0 | Multiplier for damping applied to optimized camera intrinsics. |
 | `robust_kernel` | `huber` \| `tukey` \| `gnc_tls` \| null | required | - | Robust loss for dense-flow residuals. Set to null for L2 residuals. |
 | `robust_kernel_threshold` | float | required | > 0.0 | Robust-kernel threshold in 1/8-resolution feature-map pixels. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -220,6 +220,7 @@ Bundle-adjustment solver and robust loss options.
 | Field | Type | Default | Constraints | Description |
 | --- | --- | --- | --- | --- |
 | `dense_disp_alpha` | float | required | >= 0.0 | Weight for dense-disparity regularization during bundle adjustment. |
+| `fused` | bool | required | - | Use the fused CUDA bundle-adjustment path when the graph layout is supported. |
 | `intrinsics_damping_scale` | float | required | > 0.0 | Multiplier for damping applied to optimized camera intrinsics. |
 | `robust_kernel` | `huber` \| `tukey` \| `gnc_tls` \| null | required | - | Robust loss for dense-flow residuals. Set to null for L2 residuals. |
 | `robust_kernel_threshold` | float | required | > 0.0 | Robust-kernel threshold in 1/8-resolution feature-map pixels. |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,6 +123,16 @@ def test_typed_config_pipeline_factory_compatibility(tmp_path: Path) -> None:
     assert Path(pipeline.out_cfg.path) == tmp_path / "out"
 
 
+def test_parse_typed_config_accepts_fused_ba_override(tmp_path: Path) -> None:
+    config = parse_typed_config(
+        "default",
+        [*_base_overrides(tmp_path), "pipeline.slam.ba.fused=true"],
+    )
+
+    assert isinstance(config.pipeline, DefaultPipelineConfig)
+    assert config.pipeline.slam.ba.fused is True
+
+
 @pytest.mark.parametrize(
     "override",
     [

--- a/tests/test_graph_buffer_fused_ba.py
+++ b/tests/test_graph_buffer_fused_ba.py
@@ -4,45 +4,24 @@ from __future__ import annotations
 
 import unittest
 
-try:
-    import torch
-    from omegaconf import OmegaConf
+import scipy  # noqa: F401
+import torch
+from omegaconf import OmegaConf
 
-    from vipe.ext import slam_ext
-    from vipe.slam.components.buffer import GraphBuffer
-except ImportError:  # pragma: no cover - lets discovery work without the runtime env
-    torch = None
-    OmegaConf = None
-    slam_ext = None
-    GraphBuffer = None
-
-try:
-    from vipe.slam.components.sparse_tracks import DummySparseTracks
-    from vipe.utils.cameras import CameraType
-except ImportError:  # pragma: no cover
-    DummySparseTracks = None
-    CameraType = None
-
-try:
-    import scipy  # noqa: F401
-except ImportError:  # pragma: no cover
-    scipy = None
+from vipe.ext import slam_ext
+from vipe.slam.components.buffer import GraphBuffer
+from vipe.slam.components.sparse_tracks import DummySparseTracks
+from vipe.utils.cameras import CameraType
 
 
-def _has_cuda_ba_runtime() -> bool:
-    return (
-        torch is not None
-        and torch.cuda.is_available()
-        and slam_ext is not None
-        and hasattr(slam_ext, "ba_extended")
-        and scipy is not None
-        and GraphBuffer is not None
-        and DummySparseTracks is not None
-        and CameraType is not None
-    )
+def _require_cuda_ba_runtime() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for fused BA parity tests")
+    if not hasattr(slam_ext, "ba_extended"):
+        raise RuntimeError("slam_ext.ba_extended is required for fused BA parity tests")
 
 
-class FixtureSparseTracks(DummySparseTracks if DummySparseTracks is not None else object):
+class FixtureSparseTracks(DummySparseTracks):
     def __init__(self, n_views: int, enabled: bool) -> None:
         super().__init__(n_views)
         self.enabled = enabled
@@ -207,8 +186,11 @@ def _run_fused_bundle_adjustment(video, ba_inputs, *, motion_only: bool, limited
     return used_fused_ba
 
 
-@unittest.skipUnless(_has_cuda_ba_runtime(), "CUDA slam extension and scipy are required")
 class GraphBufferFusedBATest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _require_cuda_ba_runtime()
+
     def assert_graph_buffers_close(self, actual, expected) -> None:
         torch.testing.assert_close(actual.poses[:5], expected.poses[:5], atol=2e-4, rtol=2e-4)
         torch.testing.assert_close(actual.disps[:5], expected.disps[:5], atol=2e-4, rtol=2e-4)

--- a/tests/test_graph_buffer_fused_ba.py
+++ b/tests/test_graph_buffer_fused_ba.py
@@ -164,7 +164,10 @@ def _run_generic_bundle_adjustment(
 
 def _run_fused_bundle_adjustment(video, ba_inputs, *, motion_only: bool, limited_disp: bool, optimize_intrinsics: bool):
     target, weight, disp_damping, ii, jj = ba_inputs
-    used_fused_ba = video._try_fused_ba(
+    if not video.ba_config.fused:
+        return False
+
+    video._fused_ba(
         target=target.clone(),
         weight=weight.clone(),
         disp_damping=disp_damping.clone(),
@@ -184,7 +187,7 @@ def _run_fused_bundle_adjustment(video, ba_inputs, *, motion_only: bool, limited
         verbose=False,
     )
     video.disps.clamp_(min=0.001)
-    return used_fused_ba
+    return True
 
 
 class GraphBufferFusedBATest(unittest.TestCase):

--- a/tests/test_graph_buffer_fused_ba.py
+++ b/tests/test_graph_buffer_fused_ba.py
@@ -181,6 +181,7 @@ def _run_fused_bundle_adjustment(video, ba_inputs, *, motion_only: bool, limited
         optimize_rig_rotation=False,
         weight_dense_disp=0.001,
         weight_tracks=0.001,
+        verbose=False,
     )
     video.disps.clamp_(min=0.001)
     return used_fused_ba
@@ -243,6 +244,32 @@ class GraphBufferFusedBATest(unittest.TestCase):
         self.assertTrue(used_fused_ba)
         torch.testing.assert_close(fused.disps, original_fused_disps, atol=0.0, rtol=0.0)
         self.assert_graph_buffers_close(fused, generic)
+
+    def test_fused_ba_logs_energy_when_verbose(self):
+        fused = _make_video(fused=True, sparse_tracks_enabled=False)
+        ba_inputs = _make_real_run_shaped_ba_inputs(fused)
+        target, weight, disp_damping, ii, jj = ba_inputs
+
+        with self.assertLogs("vipe.slam.components.buffer", level="INFO") as logs:
+            fused.bundle_adjustment(
+                target=target.clone(),
+                weight=weight.clone(),
+                disp_damping=disp_damping.clone(),
+                ii=ii.clone(),
+                jj=jj.clone(),
+                t0=1,
+                t1=5,
+                n_iters=1,
+                pose_damping=1e-3,
+                pose_ep=0.1,
+                motion_only=False,
+                limited_disp=False,
+                optimize_intrinsics=False,
+                optimize_rig_rotation=False,
+                verbose=True,
+            )
+
+        self.assertRegex(logs.output[-1], r"BA iters = 1, energy: [0-9.eE+-]+ -> [0-9.eE+-]+")
 
     def test_hydra_config_gate_disables_fused_ba_without_env_vars(self):
         disabled = _make_video(fused=False, sparse_tracks_enabled=False)

--- a/tests/test_graph_buffer_fused_ba.py
+++ b/tests/test_graph_buffer_fused_ba.py
@@ -1,0 +1,281 @@
+# mypy: ignore-errors
+
+from __future__ import annotations
+
+import unittest
+
+try:
+    import torch
+    from omegaconf import OmegaConf
+
+    from vipe.ext import slam_ext
+    from vipe.slam.components.buffer import GraphBuffer
+except ImportError:  # pragma: no cover - lets discovery work without the runtime env
+    torch = None
+    OmegaConf = None
+    slam_ext = None
+    GraphBuffer = None
+
+try:
+    from vipe.slam.components.sparse_tracks import DummySparseTracks
+    from vipe.utils.cameras import CameraType
+except ImportError:  # pragma: no cover
+    DummySparseTracks = None
+    CameraType = None
+
+try:
+    import scipy  # noqa: F401
+except ImportError:  # pragma: no cover
+    scipy = None
+
+
+def _has_cuda_ba_runtime() -> bool:
+    return (
+        torch is not None
+        and torch.cuda.is_available()
+        and slam_ext is not None
+        and hasattr(slam_ext, "ba_extended")
+        and scipy is not None
+        and GraphBuffer is not None
+        and DummySparseTracks is not None
+        and CameraType is not None
+    )
+
+
+class FixtureSparseTracks(DummySparseTracks if DummySparseTracks is not None else object):
+    def __init__(self, n_views: int, enabled: bool) -> None:
+        super().__init__(n_views)
+        self.enabled = enabled
+
+    def compute_dense_disp_target_weight(
+        self,
+        source_view_inds: torch.Tensor,
+        source_frame_inds: torch.Tensor,
+        target_view_inds: torch.Tensor,
+        target_frame_inds: torch.Tensor,
+        image_size: tuple[int, int],
+        dense_disp_size: tuple[int, int],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        del source_view_inds, target_view_inds, image_size
+        disp_h, disp_w = dense_disp_size
+        yy, xx = torch.meshgrid(
+            torch.arange(disp_h, device=source_frame_inds.device, dtype=torch.float32),
+            torch.arange(disp_w, device=source_frame_inds.device, dtype=torch.float32),
+            indexing="ij",
+        )
+        coords = torch.stack([xx, yy], dim=-1)
+        dt = (target_frame_inds - source_frame_inds).to(torch.float32).view(-1, 1, 1, 1)
+        target = coords.unsqueeze(0) + torch.cat([0.03 * dt, -0.02 * dt], dim=-1)
+        weight = torch.full_like(target, 0.07)
+        weight = weight * (source_frame_inds != target_frame_inds).to(torch.float32).view(-1, 1, 1, 1)
+        return target, weight
+
+
+def _ba_config(fused: bool):
+    return OmegaConf.create(
+        {
+            "dense_disp_alpha": 0.001,
+            "fused": fused,
+            "intrinsics_damping_scale": 1.0,
+            "robust_kernel": None,
+            "robust_kernel_threshold": 3.0,
+            "gnc_mu_init": 1.0,
+            "gnc_mu_step": 3.0,
+            "gnc_mu_max": 1.0e6,
+            "gnc_n_mu_steps": 4,
+            "gnc_gn_iters_per_mu": 6,
+        }
+    )
+
+
+def _make_video(fused: bool, sparse_tracks_enabled: bool):
+    torch.manual_seed(20260519)
+    device = torch.device("cuda")
+    height, width, n_frames = 32, 40, 5
+    video = GraphBuffer(
+        height=height,
+        width=width,
+        n_views=1,
+        buffer_size=6,
+        init_disp=0.8,
+        cross_view_idx=None,
+        ba_config=_ba_config(fused),
+        sparse_tracks=FixtureSparseTracks(n_views=1, enabled=sparse_tracks_enabled),
+        camera_type=CameraType.PINHOLE,
+        device=device,
+    )
+    video.n_frames = n_frames
+    video.tstamp[:n_frames] = torch.arange(n_frames, device=device)
+    video.intrinsics[0, :4] = torch.tensor([38.0, 38.0, 19.5, 15.5], device=device)
+
+    video.poses[:n_frames, 0] = torch.linspace(0.0, 0.08, n_frames, device=device)
+    video.poses[:n_frames, 1] = torch.tensor([0.0, 0.01, -0.005, 0.015, 0.02], device=device)
+    video.poses[:n_frames, 2] = torch.linspace(0.0, 0.025, n_frames, device=device)
+
+    disp_h, disp_w = height // 8, width // 8
+    yy, xx = torch.meshgrid(
+        torch.arange(disp_h, device=device, dtype=torch.float32),
+        torch.arange(disp_w, device=device, dtype=torch.float32),
+        indexing="ij",
+    )
+    base_disp = 0.72 + 0.015 * xx + 0.02 * yy
+    for frame_idx in range(n_frames):
+        video.disps[frame_idx, 0] = base_disp + 0.025 * frame_idx
+
+    video.disps_sens[2, 0] = video.disps[2, 0] * 1.015
+    video.disps_sens[4, 0] = video.disps[4, 0] * 0.985
+    return video
+
+
+def _make_real_run_shaped_ba_inputs(video):
+    device = video.device
+    disp_h, disp_w = video.height // 8, video.width // 8
+    ii = torch.tensor([1, 2, 3, 4, 0, 3], device=device, dtype=torch.long)
+    jj = torch.tensor([0, 0, 1, 2, 2, 3], device=device, dtype=torch.long)
+
+    coords, _ = video.reproject_dense_disp(ii, jj)
+    target = coords.reshape(ii.shape[0], disp_h * disp_w, 2).clone()
+
+    yy, xx = torch.meshgrid(
+        torch.arange(disp_h, device=device, dtype=torch.float32),
+        torch.arange(disp_w, device=device, dtype=torch.float32),
+        indexing="ij",
+    )
+    spatial_delta = torch.stack(
+        [
+            0.01 * torch.sin(0.7 * xx + 0.2 * yy),
+            -0.012 * torch.cos(0.3 * xx - 0.5 * yy),
+        ],
+        dim=-1,
+    ).reshape(1, disp_h * disp_w, 2)
+    edge_delta = torch.linspace(-0.015, 0.02, ii.shape[0], device=device).view(-1, 1, 1)
+    target = target + spatial_delta + torch.cat([edge_delta, -0.5 * edge_delta], dim=-1)
+
+    weight = 0.2 + 0.03 * (xx + yy).reshape(1, disp_h * disp_w, 1)
+    weight = weight.repeat(ii.shape[0], 1, 2).contiguous()
+    weight[-1].zero_()  # Degenerate self-edge: present in real graphs, but contributes nothing here.
+
+    disp_damping = 0.08 + 0.01 * torch.arange(6, device=device, dtype=torch.float32).view(-1, 1, 1)
+    disp_damping = disp_damping + 0.002 * xx.unsqueeze(0) + 0.001 * yy.unsqueeze(0)
+    return target.contiguous(), weight.contiguous(), disp_damping.contiguous(), ii, jj
+
+
+def _run_generic_bundle_adjustment(
+    video, ba_inputs, *, motion_only: bool, limited_disp: bool, optimize_intrinsics: bool
+):
+    target, weight, disp_damping, ii, jj = ba_inputs
+    video.bundle_adjustment(
+        target=target.clone(),
+        weight=weight.clone(),
+        disp_damping=disp_damping.clone(),
+        ii=ii.clone(),
+        jj=jj.clone(),
+        t0=1,
+        t1=5,
+        n_iters=1,
+        pose_damping=1e-3,
+        pose_ep=0.1,
+        motion_only=motion_only,
+        limited_disp=limited_disp,
+        optimize_intrinsics=optimize_intrinsics,
+        optimize_rig_rotation=False,
+        verbose=False,
+    )
+
+
+def _run_fused_bundle_adjustment(video, ba_inputs, *, motion_only: bool, limited_disp: bool, optimize_intrinsics: bool):
+    target, weight, disp_damping, ii, jj = ba_inputs
+    used_fused_ba = video._try_fused_ba(
+        target=target.clone(),
+        weight=weight.clone(),
+        disp_damping=disp_damping.clone(),
+        ii=ii.clone(),
+        jj=jj.clone(),
+        t0=1,
+        t1=5,
+        n_iters=1,
+        pose_damping=1e-3,
+        pose_ep=0.1,
+        motion_only=motion_only,
+        limited_disp=limited_disp,
+        optimize_intrinsics=optimize_intrinsics,
+        optimize_rig_rotation=False,
+        weight_dense_disp=0.001,
+        weight_tracks=0.001,
+    )
+    video.disps.clamp_(min=0.001)
+    return used_fused_ba
+
+
+@unittest.skipUnless(_has_cuda_ba_runtime(), "CUDA slam extension and scipy are required")
+class GraphBufferFusedBATest(unittest.TestCase):
+    def assert_graph_buffers_close(self, actual, expected) -> None:
+        torch.testing.assert_close(actual.poses[:5], expected.poses[:5], atol=2e-4, rtol=2e-4)
+        torch.testing.assert_close(actual.disps[:5], expected.disps[:5], atol=2e-4, rtol=2e-4)
+        torch.testing.assert_close(actual.intrinsics, expected.intrinsics, atol=2e-4, rtol=2e-4)
+
+    def test_fused_ba_matches_generic_solver_with_intrinsics_limited_disp_and_sparse_tracks(self):
+        generic = _make_video(fused=False, sparse_tracks_enabled=True)
+        fused = _make_video(fused=True, sparse_tracks_enabled=True)
+        ba_inputs = _make_real_run_shaped_ba_inputs(generic)
+
+        _run_generic_bundle_adjustment(
+            generic,
+            ba_inputs,
+            motion_only=False,
+            limited_disp=True,
+            optimize_intrinsics=True,
+        )
+        used_fused_ba = _run_fused_bundle_adjustment(
+            fused,
+            ba_inputs,
+            motion_only=False,
+            limited_disp=True,
+            optimize_intrinsics=True,
+        )
+
+        self.assertTrue(used_fused_ba)
+        self.assert_graph_buffers_close(fused, generic)
+
+    def test_fused_ba_matches_generic_solver_motion_only(self):
+        generic = _make_video(fused=False, sparse_tracks_enabled=False)
+        fused = _make_video(fused=True, sparse_tracks_enabled=False)
+        ba_inputs = _make_real_run_shaped_ba_inputs(generic)
+        original_fused_disps = fused.disps.clone()
+
+        _run_generic_bundle_adjustment(
+            generic,
+            ba_inputs,
+            motion_only=True,
+            limited_disp=False,
+            optimize_intrinsics=False,
+        )
+        used_fused_ba = _run_fused_bundle_adjustment(
+            fused,
+            ba_inputs,
+            motion_only=True,
+            limited_disp=False,
+            optimize_intrinsics=False,
+        )
+
+        self.assertTrue(used_fused_ba)
+        torch.testing.assert_close(fused.disps, original_fused_disps, atol=0.0, rtol=0.0)
+        self.assert_graph_buffers_close(fused, generic)
+
+    def test_hydra_config_gate_disables_fused_ba_without_env_vars(self):
+        disabled = _make_video(fused=False, sparse_tracks_enabled=False)
+        ba_inputs = _make_real_run_shaped_ba_inputs(disabled)
+
+        used_fused_ba = _run_fused_bundle_adjustment(
+            disabled,
+            ba_inputs,
+            motion_only=False,
+            limited_disp=False,
+            optimize_intrinsics=False,
+        )
+
+        self.assertFalse(used_fused_ba)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph_buffer_fused_ba.py
+++ b/tests/test_graph_buffer_fused_ba.py
@@ -271,6 +271,55 @@ class GraphBufferFusedBATest(unittest.TestCase):
 
         self.assertRegex(logs.output[-1], r"BA iters = 1, energy: [0-9.eE+-]+ -> [0-9.eE+-]+")
 
+    def test_fused_ba_errors_for_unsupported_layout_instead_of_falling_back(self):
+        fused = _make_video(fused=True, sparse_tracks_enabled=False)
+        ba_inputs = _make_real_run_shaped_ba_inputs(fused)
+        target, weight, disp_damping, ii, jj = ba_inputs
+
+        with self.assertRaisesRegex(RuntimeError, "does not support optimizing rig rotation"):
+            fused.bundle_adjustment(
+                target=target.clone(),
+                weight=weight.clone(),
+                disp_damping=disp_damping.clone(),
+                ii=ii.clone(),
+                jj=jj.clone(),
+                t0=1,
+                t1=5,
+                n_iters=1,
+                pose_damping=1e-3,
+                pose_ep=0.1,
+                motion_only=False,
+                limited_disp=False,
+                optimize_intrinsics=False,
+                optimize_rig_rotation=True,
+                verbose=False,
+            )
+
+    def test_fused_ba_errors_for_robust_kernel_instead_of_falling_back(self):
+        fused = _make_video(fused=True, sparse_tracks_enabled=False)
+        fused.ba_config.robust_kernel = "huber"
+        ba_inputs = _make_real_run_shaped_ba_inputs(fused)
+        target, weight, disp_damping, ii, jj = ba_inputs
+
+        with self.assertRaisesRegex(RuntimeError, "robust kernels are not supported"):
+            fused.bundle_adjustment(
+                target=target.clone(),
+                weight=weight.clone(),
+                disp_damping=disp_damping.clone(),
+                ii=ii.clone(),
+                jj=jj.clone(),
+                t0=1,
+                t1=5,
+                n_iters=1,
+                pose_damping=1e-3,
+                pose_ep=0.1,
+                motion_only=False,
+                limited_disp=False,
+                optimize_intrinsics=False,
+                optimize_rig_rotation=False,
+                verbose=False,
+            )
+
     def test_hydra_config_gate_disables_fused_ba_without_env_vars(self):
         disabled = _make_video(fused=False, sparse_tracks_enabled=False)
         ba_inputs = _make_real_run_shaped_ba_inputs(disabled)

--- a/tests/test_slam_ext_ba_extended.py
+++ b/tests/test_slam_ext_ba_extended.py
@@ -1,16 +1,15 @@
 import unittest
 
-try:
-    import torch
+import torch
 
-    from vipe.ext import slam_ext
-except ImportError:  # pragma: no cover - lets discovery work without the runtime env
-    torch = None
-    slam_ext = None
+from vipe.ext import slam_ext
 
 
-def _has_cuda_slam_ext() -> bool:
-    return torch is not None and torch.cuda.is_available() and slam_ext is not None
+def _require_cuda_slam_ext() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required for slam_ext BA tests")
+    if not hasattr(slam_ext, "ba_extended"):
+        raise RuntimeError("slam_ext.ba_extended is required for slam_ext BA tests")
 
 
 def _make_ba_inputs(device: str = "cuda"):
@@ -34,8 +33,11 @@ def _make_ba_inputs(device: str = "cuda"):
     return poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj
 
 
-@unittest.skipUnless(_has_cuda_slam_ext(), "CUDA slam extension is required")
 class SlamExtBAExtendedTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        _require_cuda_slam_ext()
+
     def test_extended_matches_legacy_when_optional_features_are_disabled(self):
         inputs = _make_ba_inputs()
         poses0, disps0, intrinsics0, disps_sens, targets, weights, eta, ii, jj = inputs

--- a/tests/test_slam_ext_ba_extended.py
+++ b/tests/test_slam_ext_ba_extended.py
@@ -126,6 +126,40 @@ class SlamExtBAExtendedTest(unittest.TestCase):
         self.assertGreater((intrinsics[:2] - original_intrinsics[:2]).abs().max().item(), 0.0)
         torch.testing.assert_close(disps[1], original_disps[1], atol=0.0, rtol=0.0)
 
+    def test_extended_returns_kernel_energy_when_requested(self):
+        inputs = _make_ba_inputs()
+        poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj = inputs
+        depth_active = torch.ones(poses.shape[0], device=poses.device)
+
+        _, _, energy = slam_ext.ba_extended(
+            poses,
+            disps,
+            intrinsics,
+            disps_sens,
+            targets,
+            weights,
+            eta,
+            ii,
+            jj,
+            depth_active,
+            1,
+            4,
+            2,
+            1e-3,
+            0.1,
+            False,
+            0.001,
+            False,
+            1e-6,
+            1e-6,
+            0.125,
+            True,
+        )
+
+        self.assertEqual(tuple(energy.shape), (2,))
+        self.assertTrue(torch.isfinite(energy).all().item())
+        self.assertGreater(energy[0].item(), 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_slam_ext_ba_extended.py
+++ b/tests/test_slam_ext_ba_extended.py
@@ -1,0 +1,129 @@
+import unittest
+
+try:
+    import torch
+
+    from vipe.ext import slam_ext
+except ImportError:  # pragma: no cover - lets discovery work without the runtime env
+    torch = None
+    slam_ext = None
+
+
+def _has_cuda_slam_ext() -> bool:
+    return torch is not None and torch.cuda.is_available() and slam_ext is not None
+
+
+def _make_ba_inputs(device: str = "cuda"):
+    torch.manual_seed(2026)
+    n_frames, height, width, n_edges = 4, 4, 5, 5
+
+    poses = torch.zeros(n_frames, 7, device=device)
+    poses[:, 6] = 1.0
+    poses[:, 0] = torch.linspace(0.0, 0.03, n_frames, device=device)
+
+    disps = torch.ones(n_frames, height, width, device=device) * 0.8
+    disps_sens = torch.zeros_like(disps)
+    intrinsics = torch.tensor([40.0, 40.0, 2.0, 2.0], device=device)
+    targets = torch.rand(n_edges, 2, height, width, device=device) * 3.0
+    weights = torch.rand(n_edges, 2, height, width, device=device)
+    ii = torch.tensor([1, 2, 2, 3, 3], device=device, dtype=torch.long)
+    jj = torch.tensor([0, 0, 1, 1, 2], device=device, dtype=torch.long)
+    kx = torch.unique(torch.cat([torch.arange(1, 4, device=device), ii]))
+    eta = torch.ones(n_frames, height, width, device=device)[kx].contiguous() * 0.1
+
+    return poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj
+
+
+@unittest.skipUnless(_has_cuda_slam_ext(), "CUDA slam extension is required")
+class SlamExtBAExtendedTest(unittest.TestCase):
+    def test_extended_matches_legacy_when_optional_features_are_disabled(self):
+        inputs = _make_ba_inputs()
+        poses0, disps0, intrinsics0, disps_sens, targets, weights, eta, ii, jj = inputs
+        poses1 = poses0.clone()
+        disps1 = disps0.clone()
+        depth_active = torch.ones(poses0.shape[0], device=poses0.device)
+
+        slam_ext.ba(
+            poses0,
+            disps0,
+            intrinsics0.clone(),
+            disps_sens,
+            targets,
+            weights,
+            eta,
+            ii,
+            jj,
+            1,
+            4,
+            1,
+            1e-3,
+            0.1,
+            False,
+            0.001,
+        )
+        slam_ext.ba_extended(
+            poses1,
+            disps1,
+            intrinsics0.clone(),
+            disps_sens,
+            targets,
+            weights,
+            eta,
+            ii,
+            jj,
+            depth_active,
+            1,
+            4,
+            1,
+            1e-3,
+            0.1,
+            False,
+            0.001,
+            False,
+            1e-6,
+            1e-6,
+            0.125,
+        )
+
+        torch.testing.assert_close(poses1, poses0, atol=0.0, rtol=0.0)
+        torch.testing.assert_close(disps1, disps0, atol=0.0, rtol=0.0)
+
+    def test_extended_optimizes_intrinsics_and_masks_limited_disparities(self):
+        inputs = _make_ba_inputs()
+        poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj = inputs
+        original_disps = disps.clone()
+        original_intrinsics = intrinsics.clone()
+        depth_active = torch.ones(poses.shape[0], device=poses.device)
+        depth_active[1] = 0.0
+
+        slam_ext.ba_extended(
+            poses,
+            disps,
+            intrinsics,
+            disps_sens,
+            targets,
+            weights,
+            eta,
+            ii,
+            jj,
+            depth_active,
+            1,
+            4,
+            1,
+            1e-3,
+            0.1,
+            False,
+            0.001,
+            True,
+            1e-6,
+            1e-6,
+            0.125,
+        )
+
+        self.assertTrue(torch.isfinite(intrinsics).all().item())
+        self.assertGreater((intrinsics[:2] - original_intrinsics[:2]).abs().max().item(), 0.0)
+        torch.testing.assert_close(disps[1], original_disps[1], atol=0.0, rtol=0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vipe/config/slam.py
+++ b/vipe/config/slam.py
@@ -17,7 +17,7 @@ class BAConfig(BaseConfigSchema):
         ge=0.0,
         description="Weight for dense-disparity regularization during bundle adjustment.",
     )
-    fused: bool = Field(description="Use the fused CUDA bundle-adjustment path when the graph layout is supported.")
+    fused: bool = Field(description="Use the fused CUDA bundle-adjustment path; unsupported layouts raise an error.")
     intrinsics_damping_scale: float = Field(
         gt=0.0,
         description="Multiplier for damping applied to optimized camera intrinsics.",

--- a/vipe/config/slam.py
+++ b/vipe/config/slam.py
@@ -17,6 +17,7 @@ class BAConfig(BaseConfigSchema):
         ge=0.0,
         description="Weight for dense-disparity regularization during bundle adjustment.",
     )
+    fused: bool = Field(description="Use the fused CUDA bundle-adjustment path when the graph layout is supported.")
     intrinsics_damping_scale: float = Field(
         gt=0.0,
         description="Multiplier for damping applied to optimized camera intrinsics.",

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -379,6 +379,7 @@ class GraphBuffer:
         optimize_rig_rotation: bool,
         weight_dense_disp: float,
         weight_tracks: float,
+        verbose: bool,
     ) -> bool:
         if not bool(self.ba_config.get("fused", False)):
             return False
@@ -448,6 +449,21 @@ class GraphBuffer:
             depth_active[t0:t1] = 1.0
 
         intrinsics_damping_scale = self.ba_config.get("intrinsics_damping_scale", 1.0)
+        initial_energy = (
+            self._compute_fused_ba_energy(
+                target=target,
+                weight=weight,
+                ii=ii,
+                jj=jj,
+                kx=kx,
+                intrinsics=intrinsics,
+                depth_active=depth_active,
+                motion_only=motion_only,
+                weight_dense_disp=weight_dense_disp,
+            )
+            if verbose
+            else None
+        )
 
         try:
             slam_ext.ba_extended(
@@ -476,10 +492,67 @@ class GraphBuffer:
         except (AttributeError, TypeError):
             return False
 
+        if verbose:
+            final_energy = self._compute_fused_ba_energy(
+                target=target,
+                weight=weight,
+                ii=ii,
+                jj=jj,
+                kx=kx,
+                intrinsics=intrinsics,
+                depth_active=depth_active,
+                motion_only=motion_only,
+                weight_dense_disp=weight_dense_disp,
+            )
+            logger.info(f"BA iters = {n_iters}, energy: {initial_energy} -> {final_energy}")
+
         if optimize_intrinsics:
             self.intrinsics[0, :4] = intrinsics / intrinsics_scale
 
         return True
+
+    def _compute_fused_ba_energy(
+        self,
+        *,
+        target: torch.Tensor,
+        weight: torch.Tensor,
+        ii: torch.Tensor,
+        jj: torch.Tensor,
+        kx: torch.Tensor,
+        intrinsics: torch.Tensor,
+        depth_active: torch.Tensor,
+        motion_only: bool,
+        weight_dense_disp: float,
+    ) -> float:
+        qi = torch.zeros_like(ii)
+        qj = torch.zeros_like(jj)
+        coords, valid_mask, _, _, _ = geom.iproj_i_proj_j_disp(
+            SE3(self.poses),
+            self.disps[:, 0],
+            None,
+            intrinsics[None],
+            self.camera_type,
+            SE3(self.rig),
+            ii,
+            jj,
+            qi,
+            qj,
+            ii,
+            jacobian_p_d=False,
+            jacobian_f=False,
+            jacobian_r=False,
+        )
+        target = rearrange(target, "k c h w -> k h w c", c=2)
+        weight = rearrange(weight, "k c h w -> k h w c", c=2)
+        flow_energy = ((coords - target).square() * valid_mask * (weight_dense_disp * weight)).sum()
+
+        if motion_only:
+            return float(flow_energy.item())
+
+        sens = self.disps_sens[kx, 0]
+        sens_mask = (sens > 0).to(dtype=self.disps.dtype) * depth_active[kx].view(-1, 1, 1)
+        sens_energy = (self.ba_config.dense_disp_alpha * (self.disps[kx, 0] - sens).square() * sens_mask).sum()
+        return float((flow_energy + sens_energy).item())
 
     def expand_tracks_edges(self, ii: torch.Tensor, tracks_length: int):
         iis = [ii] * (tracks_length - 1)
@@ -547,6 +620,7 @@ class GraphBuffer:
             optimize_rig_rotation,
             weight_dense_disp,
             weight_tracks,
+            verbose,
         ):
             self.disps.clamp_(min=0.001)
             return

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -361,7 +361,7 @@ class GraphBuffer:
             dj.reshape(-1),
         )
 
-    def _try_fused_ba(
+    def _fused_ba(
         self,
         target: torch.Tensor,
         weight: torch.Tensor,
@@ -380,12 +380,10 @@ class GraphBuffer:
         weight_dense_disp: float,
         weight_tracks: float,
         verbose: bool,
-    ) -> bool:
+    ) -> None:
         def fail(reason: str) -> None:
             raise RuntimeError(f"Fused BA is enabled, but {reason}. Set ba.fused=false to use the generic BA solver.")
 
-        if not bool(self.ba_config.get("fused", False)):
-            return False
         if self.n_views != 1 or self.camera_type != CameraType.PINHOLE:
             fail("it only supports single-view pinhole-camera graph buffers")
         if optimize_rig_rotation:
@@ -490,8 +488,6 @@ class GraphBuffer:
         if optimize_intrinsics:
             self.intrinsics[0, :4] = intrinsics / intrinsics_scale
 
-        return True
-
     def expand_tracks_edges(self, ii: torch.Tensor, tracks_length: int):
         iis = [ii] * (tracks_length - 1)
         jjs = [ii - m - 1 for m in range(tracks_length - 1)]
@@ -541,31 +537,32 @@ class GraphBuffer:
             gnc_mu_max=float(self.ba_config.get("gnc_mu_max", 1.0e6)),
         )
 
-        if bool(self.ba_config.get("fused", False)) and robust_kernel is not None:
-            raise RuntimeError(
-                "Fused BA is enabled, but robust kernels are not supported. "
-                "Set ba.fused=false to use the generic BA solver."
-            )
+        if self.ba_config.fused:
+            if robust_kernel is not None:
+                raise RuntimeError(
+                    "Fused BA is enabled, but robust kernels are not supported. "
+                    "Set ba.fused=false to use the generic BA solver."
+                )
 
-        if self._try_fused_ba(
-            target,
-            weight,
-            disp_damping,
-            ii,
-            jj,
-            t0,
-            t1,
-            n_iters,
-            pose_damping,
-            pose_ep,
-            motion_only,
-            limited_disp,
-            optimize_intrinsics,
-            optimize_rig_rotation,
-            weight_dense_disp,
-            weight_tracks,
-            verbose,
-        ):
+            self._fused_ba(
+                target,
+                weight,
+                disp_damping,
+                ii,
+                jj,
+                t0,
+                t1,
+                n_iters,
+                pose_damping,
+                pose_ep,
+                motion_only,
+                limited_disp,
+                optimize_intrinsics,
+                optimize_rig_rotation,
+                weight_dense_disp,
+                weight_tracks,
+                verbose,
+            )
             self.disps.clamp_(min=0.001)
             return
 

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -449,24 +449,9 @@ class GraphBuffer:
             depth_active[t0:t1] = 1.0
 
         intrinsics_damping_scale = self.ba_config.get("intrinsics_damping_scale", 1.0)
-        initial_energy = (
-            self._compute_fused_ba_energy(
-                target=target,
-                weight=weight,
-                ii=ii,
-                jj=jj,
-                kx=kx,
-                intrinsics=intrinsics,
-                depth_active=depth_active,
-                motion_only=motion_only,
-                weight_dense_disp=weight_dense_disp,
-            )
-            if verbose
-            else None
-        )
 
         try:
-            slam_ext.ba_extended(
+            _, _, ba_energy = slam_ext.ba_extended(
                 self.poses,
                 self.disps[:, 0],
                 intrinsics,
@@ -488,71 +473,18 @@ class GraphBuffer:
                 1e-6 * intrinsics_damping_scale,
                 1e-6 * intrinsics_damping_scale,
                 intrinsics_scale,
+                verbose,
             )
         except (AttributeError, TypeError):
             return False
 
         if verbose:
-            final_energy = self._compute_fused_ba_energy(
-                target=target,
-                weight=weight,
-                ii=ii,
-                jj=jj,
-                kx=kx,
-                intrinsics=intrinsics,
-                depth_active=depth_active,
-                motion_only=motion_only,
-                weight_dense_disp=weight_dense_disp,
-            )
-            logger.info(f"BA iters = {n_iters}, energy: {initial_energy} -> {final_energy}")
+            logger.info(f"BA iters = {n_iters}, energy: {ba_energy[0].item()} -> {ba_energy[-1].item()}")
 
         if optimize_intrinsics:
             self.intrinsics[0, :4] = intrinsics / intrinsics_scale
 
         return True
-
-    def _compute_fused_ba_energy(
-        self,
-        *,
-        target: torch.Tensor,
-        weight: torch.Tensor,
-        ii: torch.Tensor,
-        jj: torch.Tensor,
-        kx: torch.Tensor,
-        intrinsics: torch.Tensor,
-        depth_active: torch.Tensor,
-        motion_only: bool,
-        weight_dense_disp: float,
-    ) -> float:
-        qi = torch.zeros_like(ii)
-        qj = torch.zeros_like(jj)
-        coords, valid_mask, _, _, _ = geom.iproj_i_proj_j_disp(
-            SE3(self.poses),
-            self.disps[:, 0],
-            None,
-            intrinsics[None],
-            self.camera_type,
-            SE3(self.rig),
-            ii,
-            jj,
-            qi,
-            qj,
-            ii,
-            jacobian_p_d=False,
-            jacobian_f=False,
-            jacobian_r=False,
-        )
-        target = rearrange(target, "k c h w -> k h w c", c=2)
-        weight = rearrange(weight, "k c h w -> k h w c", c=2)
-        flow_energy = ((coords - target).square() * valid_mask * (weight_dense_disp * weight)).sum()
-
-        if motion_only:
-            return float(flow_energy.item())
-
-        sens = self.disps_sens[kx, 0]
-        sens_mask = (sens > 0).to(dtype=self.disps.dtype) * depth_active[kx].view(-1, 1, 1)
-        sens_energy = (self.ba_config.dense_disp_alpha * (self.disps[kx, 0] - sens).square() * sens_mask).sum()
-        return float((flow_energy + sens_energy).item())
 
     def expand_tracks_edges(self, ii: torch.Tensor, tracks_length: int):
         iis = [ii] * (tracks_length - 1)

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -361,6 +361,126 @@ class GraphBuffer:
             dj.reshape(-1),
         )
 
+    def _try_fused_ba(
+        self,
+        target: torch.Tensor,
+        weight: torch.Tensor,
+        disp_damping: torch.Tensor,
+        ii: torch.Tensor,
+        jj: torch.Tensor,
+        t0: int,
+        t1: int,
+        n_iters: int,
+        pose_damping: float,
+        pose_ep: float,
+        motion_only: bool,
+        limited_disp: bool,
+        optimize_intrinsics: bool,
+        optimize_rig_rotation: bool,
+        weight_dense_disp: float,
+        weight_tracks: float,
+    ) -> bool:
+        if not bool(self.ba_config.get("fused", False)):
+            return False
+        if self.n_views != 1 or self.camera_type != CameraType.PINHOLE:
+            return False
+        if optimize_rig_rotation:
+            return False
+        if t0 >= t1:
+            return False
+        if target.shape[0] != ii.shape[0] or weight.shape[0] != ii.shape[0]:
+            return False
+        # The DROID CUDA kernel applies the 0.001 dense-flow scale internally.
+        if weight_dense_disp != 0.001 or weight_tracks != 0.001:
+            return False
+
+        edge_mask = ii != jj
+        if not torch.any(edge_mask):
+            return False
+        if not torch.all(edge_mask):
+            ii = ii[edge_mask]
+            jj = jj[edge_mask]
+            target = target[edge_mask]
+            weight = weight[edge_mask]
+
+        identity_rig = torch.as_tensor([0, 0, 0, 0, 0, 0, 1], dtype=self.rig.dtype, device=self.rig.device)
+        if not torch.allclose(self.rig[0], identity_rig):
+            return False
+
+        ht, wd = self.height // 8, self.width // 8
+
+        if self.sparse_tracks.enabled:
+            view_inds = torch.zeros_like(ii)
+            sparse_target, sparse_weight = self.sparse_tracks.compute_dense_disp_target_weight(
+                source_view_inds=view_inds,
+                source_frame_inds=self.tstamp[ii],
+                target_view_inds=view_inds,
+                target_frame_inds=self.tstamp[jj],
+                image_size=(self.height, self.width),
+                dense_disp_size=(ht, wd),
+            )
+            sparse_target = sparse_target.flatten(1, 2)
+            sparse_weight = sparse_weight.flatten(1, 2)
+            combined_weight = weight + sparse_weight
+            combined_target = torch.where(
+                combined_weight > 0,
+                (weight * target + sparse_weight * sparse_target) / combined_weight.clamp_min(1e-12),
+                target,
+            )
+            target, weight = combined_target, combined_weight
+
+        target = rearrange(target, "k (h w) c -> k c h w", h=ht, w=wd, c=2).contiguous()
+        weight = rearrange(weight, "k (h w) c -> k c h w", h=ht, w=wd, c=2).contiguous()
+
+        kx = torch.unique(torch.cat([torch.arange(t0, t1, device=self.device), ii]))
+        eta = (0.2 * disp_damping[kx] + 1e-7).contiguous()
+        intrinsics_scale = 1.0 / 8.0
+        intrinsics = (
+            self.camera_type.build_camera_model(self.intrinsics)
+            .pinhole()
+            .scaled(intrinsics_scale)
+            .intrinsics[0]
+            .contiguous()
+        )
+        depth_active = torch.ones(self.disps.shape[0], dtype=self.disps.dtype, device=self.device)
+        if limited_disp:
+            depth_active.zero_()
+            depth_active[t0:t1] = 1.0
+
+        intrinsics_damping_scale = self.ba_config.get("intrinsics_damping_scale", 1.0)
+
+        try:
+            slam_ext.ba_extended(
+                self.poses,
+                self.disps[:, 0],
+                intrinsics,
+                self.disps_sens[:, 0],
+                target,
+                weight,
+                eta,
+                ii.contiguous(),
+                jj.contiguous(),
+                depth_active.contiguous(),
+                t0,
+                t1,
+                n_iters,
+                pose_damping,
+                pose_ep,
+                motion_only,
+                float(self.ba_config.dense_disp_alpha),
+                bool(optimize_intrinsics),
+                1e-6 * intrinsics_damping_scale,
+                1e-6 * intrinsics_damping_scale,
+                intrinsics_scale,
+            )
+        except (AttributeError, TypeError):
+            return False
+
+        if optimize_intrinsics:
+            self.intrinsics[0, :4] = intrinsics / intrinsics_scale
+
+        return True
+
     def expand_tracks_edges(self, ii: torch.Tensor, tracks_length: int):
         iis = [ii] * (tracks_length - 1)
         jjs = [ii - m - 1 for m in range(tracks_length - 1)]
@@ -402,7 +522,6 @@ class GraphBuffer:
         di_unique = torch.unique(di)
         pi_unique = torch.unique(ii)  # Should be equivalent to unique(pi)
 
-        solver = Solver(compute_energy=verbose)
         robust_kernel = build_robust_kernel(
             name=self.ba_config.get("robust_kernel", None),
             threshold=float(self.ba_config.get("robust_kernel_threshold", 1.0)),
@@ -410,6 +529,29 @@ class GraphBuffer:
             gnc_mu_step=float(self.ba_config.get("gnc_mu_step", 1.4)),
             gnc_mu_max=float(self.ba_config.get("gnc_mu_max", 1.0e6)),
         )
+
+        if robust_kernel is None and self._try_fused_ba(
+            target,
+            weight,
+            disp_damping,
+            ii,
+            jj,
+            t0,
+            t1,
+            n_iters,
+            pose_damping,
+            pose_ep,
+            motion_only,
+            limited_disp,
+            optimize_intrinsics,
+            optimize_rig_rotation,
+            weight_dense_disp,
+            weight_tracks,
+        ):
+            self.disps.clamp_(min=0.001)
+            return
+
+        solver = Solver(compute_energy=verbose)
         solver.add_term(
             DenseDepthFlowTerm(
                 pose_i_inds=pi,

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -381,23 +381,26 @@ class GraphBuffer:
         weight_tracks: float,
         verbose: bool,
     ) -> bool:
+        def fail(reason: str) -> None:
+            raise RuntimeError(f"Fused BA is enabled, but {reason}. Set ba.fused=false to use the generic BA solver.")
+
         if not bool(self.ba_config.get("fused", False)):
             return False
         if self.n_views != 1 or self.camera_type != CameraType.PINHOLE:
-            return False
+            fail("it only supports single-view pinhole-camera graph buffers")
         if optimize_rig_rotation:
-            return False
+            fail("it does not support optimizing rig rotation")
         if t0 >= t1:
-            return False
+            fail("the active optimization range is empty")
         if target.shape[0] != ii.shape[0] or weight.shape[0] != ii.shape[0]:
-            return False
+            fail("target/weight edge counts do not match the graph edges")
         # The DROID CUDA kernel applies the 0.001 dense-flow scale internally.
         if weight_dense_disp != 0.001 or weight_tracks != 0.001:
-            return False
+            fail("the configured dense-flow or sparse-track weights are unsupported")
 
         edge_mask = ii != jj
         if not torch.any(edge_mask):
-            return False
+            fail("the graph contains no non-self edges")
         if not torch.all(edge_mask):
             ii = ii[edge_mask]
             jj = jj[edge_mask]
@@ -406,7 +409,7 @@ class GraphBuffer:
 
         identity_rig = torch.as_tensor([0, 0, 0, 0, 0, 0, 1], dtype=self.rig.dtype, device=self.rig.device)
         if not torch.allclose(self.rig[0], identity_rig):
-            return False
+            fail("it only supports identity rig extrinsics")
 
         ht, wd = self.height // 8, self.width // 8
 
@@ -475,8 +478,11 @@ class GraphBuffer:
                 intrinsics_scale,
                 verbose,
             )
-        except (AttributeError, TypeError):
-            return False
+        except (AttributeError, TypeError) as exc:
+            raise RuntimeError(
+                "Fused BA is enabled, but the loaded vipe_ext runtime does not match the fused BA API. "
+                "Rebuild the extension or run with VIPE_EXT_JIT=1."
+            ) from exc
 
         if verbose:
             logger.info(f"BA iters = {n_iters}, energy: {ba_energy[0].item()} -> {ba_energy[-1].item()}")
@@ -535,7 +541,13 @@ class GraphBuffer:
             gnc_mu_max=float(self.ba_config.get("gnc_mu_max", 1.0e6)),
         )
 
-        if robust_kernel is None and self._try_fused_ba(
+        if bool(self.ba_config.get("fused", False)) and robust_kernel is not None:
+            raise RuntimeError(
+                "Fused BA is enabled, but robust kernels are not supported. "
+                "Set ba.fused=false to use the generic BA solver."
+            )
+
+        if self._try_fused_ba(
             target,
             weight,
             disp_damping,


### PR DESCRIPTION
Summary:
- Add a fused CUDA BA path exposed by `pipeline.slam.ba.fused`.
- Preserve the existing generic PyTorch BA solver as the default and fall back when the graph layout is unsupported.
- Add `slam_ext.ba_extended` for optional depth masking and intrinsic optimization.
- Add parity tests comparing fused BA against the generic solver on real-run-shaped graph-buffer data, including motion-only, limited disparity, intrinsic optimization, sparse-track combination, and a zero-weight self-edge corner case.

Notes:
- The fused path keeps the DROID kernel's internal 0.001 flow-weight convention guarded in Python.
- The CUDA path now includes dense-disparity damping alongside sensor-depth regularization to match ViPE's generic solver semantics.
- Verbose fused BA logging now reports energy computed from the CUDA path rather than launching an extra Python-side energy recomputation.

Benchmark:
- Video: `/home/huangjh/Downloads/lyra2-temple.mp4` with `pipeline=default` (762 frames processed).
- Common overrides: `pipeline.output.save_viz=false`, `pipeline.post.depth_align_model=null`, `pipeline.output.save_artifacts=false`, `pipeline.output.save_slam_map=false`; SLAM keyframe depth remains at the `pipeline=default` setting.
- Command env: `CUDA_HOME=/usr/local/cuda-12.8 VIPE_EXT_JIT=1 MAX_JOBS=8`.
- Extension JIT was already built (`ninja: no work to do`), so compile time is not included.

End-to-end wall time:

| config | run 1 | run 2 | mean |
|---|---:|---:|---:|
| `pipeline.slam.ba.fused=false` | 115.74s | 116.03s | 115.88s |
| `pipeline.slam.ba.fused=true` | 78.60s | 78.20s | 78.40s |

End-to-end delta: 37.48s saved, 32.3% lower wall time, 1.48x speedup.

Isolated BA timing:

| run | `ba.fused=false` BA time | `ba.fused=true` BA time | saved | BA speedup |
|---|---:|---:|---:|---:|
| 1 | 45.05s | 8.01s | 37.04s | 5.63x |
| 2 | 45.39s | 7.75s | 37.64s | 5.86x |
| mean | 45.22s | 7.88s | 37.34s | 5.74x |

BA-only method: timed `GraphBuffer.bundle_adjustment` with CUDA synchronization before and after each call, using the same video and common overrides. Each run made 1723 BA calls. Isolated BA time drops by about 82.6%, and the BA-only saving accounts for essentially all of the measured end-to-end saving on this benchmark.

Validation:
- `CUDA_HOME=/usr/local/cuda-12.8 VIPE_EXT_JIT=1 MAX_JOBS=8 uv run python -m unittest tests.test_graph_buffer_fused_ba -v`
- `CUDA_HOME=/usr/local/cuda-12.8 VIPE_EXT_JIT=1 MAX_JOBS=8 uv run python -m unittest tests.test_slam_ext_ba_extended -v`
- `uv run pytest tests/test_config.py -q`
- `uv run ruff format --check vipe/config/slam.py vipe/slam/components/buffer.py tests/test_config.py tests/test_graph_buffer_fused_ba.py tests/test_slam_ext_ba_extended.py`
- `uv run ruff check vipe/config/slam.py vipe/slam/components/buffer.py tests/test_config.py tests/test_graph_buffer_fused_ba.py tests/test_slam_ext_ba_extended.py`
- `uv run mypy vipe/config/slam.py vipe/slam/components/buffer.py tests/test_config.py tests/test_graph_buffer_fused_ba.py`