### PR TITLE
Bump nvidia-vipe to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ ignore_missing_imports = true
 
 [project]
 name = "nvidia-vipe"
-version = "1.0.0"
+version = "1.1.0"
 description = "NVIDIA Video Pose Engine"
 authors = [
     {name = "The ViPE Authors", email = "jiahuih@nvidia.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -2340,7 +2340,7 @@ wheels = [
 
 [[package]]
 name = "nvidia-vipe"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump the nvidia-vipe package version to 1.1.0
- Update the uv lock entry for the editable package

## Validation
- uv lock --check
- uv run ruff check pyproject.toml
- uv run python -m build --sdist --outdir /tmp/vipe-dist-check
- uv run --dev twine check /tmp/vipe-dist-check/nvidia_vipe-1.1.0.tar.gz