### PR TITLE
Reduce CPU memory usage for long videos

### DIFF
--- a/tests/test_memory_usage.py
+++ b/tests/test_memory_usage.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+import torch
+
+from vipe.streams.base import CachedVideoStream, FrameAttribute, VideoFrame, VideoStream
+from vipe.utils.cameras import CameraType
+from vipe.utils.io import ArtifactPath, read_depth_artifacts, save_artifacts
+
+
+class SinglePassStream(VideoStream):
+    def __init__(self, n_frames: int = 2) -> None:
+        self.n_frames = n_frames
+        self.n_iterations = 0
+
+    def frame_size(self) -> tuple[int, int]:
+        return (8, 8)
+
+    def name(self) -> str:
+        return "single_pass"
+
+    def fps(self) -> float:
+        return 30.0
+
+    def __len__(self) -> int:
+        return self.n_frames
+
+    def __iter__(self) -> Iterator[VideoFrame]:
+        if self.n_iterations > 0:
+            raise AssertionError("stream was iterated more than once")
+        self.n_iterations += 1
+        for frame_idx in range(self.n_frames):
+            yield VideoFrame(
+                raw_frame_idx=frame_idx,
+                rgb=torch.full((8, 8, 3), frame_idx / 10.0, dtype=torch.float32),
+                intrinsics=torch.tensor([4.0, 4.0, 4.0, 4.0]),
+                camera_type=CameraType.PINHOLE,
+                metric_depth=torch.ones((8, 8), dtype=torch.float32) * (frame_idx + 1),
+                instance=torch.full((8, 8), frame_idx + 1, dtype=torch.uint8),
+                instance_phrases={frame_idx + 1: f"object-{frame_idx}"},
+            )
+
+    def attributes(self) -> set[FrameAttribute]:
+        return {
+            FrameAttribute.INTRINSICS,
+            FrameAttribute.CAMERA_TYPE,
+            FrameAttribute.METRIC_DEPTH,
+            FrameAttribute.INSTANCE,
+        }
+
+
+def test_save_artifacts_streams_in_single_pass(tmp_path) -> None:
+    stream = SinglePassStream(n_frames=2)
+    artifact_path = ArtifactPath(tmp_path, stream.name())
+
+    save_artifacts(artifact_path, stream)
+
+    assert stream.n_iterations == 1
+    assert artifact_path.rgb_path.exists()
+    assert artifact_path.intrinsics_path.exists()
+    assert artifact_path.camera_type_path.exists()
+    assert artifact_path.depth_path.exists()
+    assert artifact_path.mask_path.exists()
+    assert artifact_path.mask_phrase_path.read_text().splitlines() == ["1: object-0", "2: object-1"]
+    assert [frame_idx for frame_idx, _ in read_depth_artifacts(artifact_path.depth_path)] == [0, 1]
+
+
+def test_compact_cpu_frame_storage_uses_uint8_rgb() -> None:
+    frame = VideoFrame(raw_frame_idx=0, rgb=torch.rand((8, 8, 3), dtype=torch.float32))
+
+    compact = frame.cpu(compact_rgb=True)
+
+    assert compact.rgb.dtype == torch.uint8
+    restored = compact.rgb.float() / 255.0
+    assert torch.allclose(restored, frame.rgb, atol=1 / 255)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CachedVideoStream restores cached frames on CUDA")
+def test_cached_video_stream_compacts_rgb_storage() -> None:
+    stream = SinglePassStream(n_frames=1)
+    cached = CachedVideoStream(stream)
+
+    _ = cached[0]
+
+    assert cached.data[0].rgb.dtype == torch.uint8

--- a/vipe/cli/main.py
+++ b/vipe/cli/main.py
@@ -19,7 +19,7 @@ import click
 
 from vipe import make_pipeline
 from vipe.config import parse_typed_config
-from vipe.streams.base import ProcessedVideoStream
+from vipe.streams.base import ProcessedVideoStream, VideoStream
 from vipe.streams.frame_dir_stream import FrameDirStream
 from vipe.streams.raw_mp4_stream import RawMp4Stream
 from vipe.utils.logging import configure_logging
@@ -42,7 +42,12 @@ from vipe.utils.viser import run_viser
 )
 @click.option("--pipeline", "-p", default="default", help="Pipeline configuration to use (default: 'default')")
 @click.option("--visualize", "-v", is_flag=True, help="Enable visualization of intermediate results")
-def infer(video: Path | None, image_dir: Path | None, output: Path, pipeline: str, visualize: bool):
+@click.option(
+    "--cache-input",
+    is_flag=True,
+    help="Preload decoded input frames before running. Use only for malformed videos that cannot be streamed twice.",
+)
+def infer(video: Path | None, image_dir: Path | None, output: Path, pipeline: str, visualize: bool, cache_input: bool):
     """Run inference on a video file or directory of images."""
 
     logger = configure_logging()
@@ -77,11 +82,15 @@ def infer(video: Path | None, image_dir: Path | None, output: Path, pipeline: st
 
     if image_dir:
         # Use frame directory stream
-        video_stream = ProcessedVideoStream(FrameDirStream(image_dir), []).cache(desc="Reading image frames")
+        video_stream: VideoStream = FrameDirStream(image_dir)
+        if cache_input:
+            video_stream = ProcessedVideoStream(video_stream, []).cache(desc="Reading image frames")
     else:
         assert video is not None
-        # Some input videos can be malformed, so we need to cache the videos to obtain correct number of frames.
-        video_stream = ProcessedVideoStream(RawMp4Stream(video), []).cache(desc="Reading video stream")
+        video_stream = RawMp4Stream(video)
+        if cache_input:
+            # Some input videos can be malformed, so users may opt into caching to obtain the exact decoded frame count.
+            video_stream = ProcessedVideoStream(video_stream, []).cache(desc="Reading video stream")
 
     vipe_pipeline.run(video_stream)
     logger.info("Finished")

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -124,10 +124,14 @@ class DefaultAnnotationPipeline(Pipeline):
             annotate_output.payload = slam_output
             return annotate_output
 
-        output_streams = [
-            self._add_post_processors(view_idx, slam_stream, slam_output).cache("depth", online=True)
-            for view_idx, slam_stream in enumerate(slam_streams)
-        ]
+        output_streams: list[VideoStream] = []
+        cache_output_streams = self.out_cfg.save_viz or self.return_output_streams
+        for view_idx, slam_stream in enumerate(slam_streams):
+            processed_output_stream = self._add_post_processors(view_idx, slam_stream, slam_output)
+            output_stream: VideoStream = processed_output_stream
+            if cache_output_streams:
+                output_stream = processed_output_stream.cache("depth", online=True)
+            output_streams.append(output_stream)
 
         # Dumping artifacts for all views in the streams
         for output_stream, artifact_path in zip(output_streams, artifact_paths):

--- a/vipe/pipeline/panorama.py
+++ b/vipe/pipeline/panorama.py
@@ -290,14 +290,13 @@ class PanoramaAnnotationPipeline(Pipeline):
                 )
 
         depth_align_model = self.post_cfg.depth_align_model
-        output_stream = CachedVideoStream(
-            MergedPanoramaVideoStream(
-                cached_video_stream,
-                slam_streams,
-                slam_output,
-                pano_depth_method=depth_align_model,
-            )
+        merged_stream = MergedPanoramaVideoStream(
+            cached_video_stream,
+            slam_streams,
+            slam_output,
+            pano_depth_method=depth_align_model,
         )
+        output_stream: VideoStream = CachedVideoStream(merged_stream) if self.out_cfg.save_viz else merged_stream
 
         if self.out_cfg.save_artifacts:
             io.save_artifacts(artifact_path, output_stream)
@@ -307,6 +306,7 @@ class PanoramaAnnotationPipeline(Pipeline):
                 pickle.dump({"finished": True}, f)
 
         if self.out_cfg.save_viz:
+            assert isinstance(output_stream, CachedVideoStream)
             save_projection_video(
                 artifact_path.meta_vis_path,
                 output_stream,

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -203,8 +203,8 @@ class AdaptiveDepthProcessor(StreamProcessor):
         frame_list: list[np.ndarray] = []
         frame_data_list: list[VideoFrame] = []
         for frame in frame_iterator:
-            frame_data_list.append(frame.cpu())
-            frame_list.append(frame.rgb.cpu().numpy())
+            frame_data_list.append(frame.cpu(compact_rgb=True))
+            frame_list.append((frame.rgb.cpu().numpy().clip(0, 1) * 255).round().astype(np.uint8))
 
         video_depth_model = unpack_optional(self.video_depth_model)
         video_depth_result: torch.Tensor = unpack_optional(

--- a/vipe/priors/depth/videodepthanything/video_depth.py
+++ b/vipe/priors/depth/videodepthanything/video_depth.py
@@ -111,12 +111,10 @@ class VideoDepthAnything(nn.Module):
         for frame_id in tqdm(range(0, org_video_len, frame_step)):
             cur_list = []
             for i in range(INFER_LEN):
-                # cur_list.append(torch.from_numpy(transform({'image': frame_list[frame_id+i].astype(np.float32) / 255.0})['image']).unsqueeze(0).unsqueeze(0))
-                cur_list.append(
-                    torch.from_numpy(transform({"image": frame_list[frame_id + i].astype(np.float32)})["image"])
-                    .unsqueeze(0)
-                    .unsqueeze(0)
-                )
+                image = frame_list[frame_id + i].astype(np.float32)
+                if np.issubdtype(frame_list[frame_id + i].dtype, np.integer):
+                    image /= np.iinfo(frame_list[frame_id + i].dtype).max
+                cur_list.append(torch.from_numpy(transform({"image": image})["image"]).unsqueeze(0).unsqueeze(0))
             cur_input = torch.cat(cur_list, dim=1).to(device)
             if pre_input is not None:
                 cur_input[:, :OVERLAP, ...] = pre_input[:, KEYFRAMES, ...]

--- a/vipe/streams/base.py
+++ b/vipe/streams/base.py
@@ -128,13 +128,17 @@ class VideoFrame:
         else:
             raise ValueError(f"Attribute {attribute} is not available in the frame.")
 
-    def cpu(self) -> "VideoFrame":
+    def cpu(self, compact_rgb: bool = False) -> "VideoFrame":
         def map_cpu(x):
             return x.cpu() if x is not None else None
 
+        rgb = self.rgb.cpu()
+        if compact_rgb and rgb.is_floating_point():
+            rgb = (rgb.clamp(0, 1) * 255).round().to(torch.uint8)
+
         return VideoFrame(
             raw_frame_idx=self.raw_frame_idx,
-            rgb=self.rgb.cpu(),
+            rgb=rgb,
             mask=map_cpu(self.mask),
             instance=map_cpu(self.instance),
             instance_phrases=self.instance_phrases,
@@ -149,9 +153,13 @@ class VideoFrame:
         def map_cuda(x):
             return x.cuda() if x is not None else None
 
+        rgb = self.rgb.cuda()
+        if rgb.dtype == torch.uint8:
+            rgb = rgb.float().div_(255.0)
+
         return VideoFrame(
             raw_frame_idx=self.raw_frame_idx,
-            rgb=self.rgb.cuda(),
+            rgb=rgb,
             mask=map_cuda(self.mask),
             instance=map_cuda(self.instance),
             instance_phrases=self.instance_phrases,
@@ -356,7 +364,7 @@ class CachedVideoStream(VideoStream):
 
     DISPLAY_THRESH = 20
 
-    def __init__(self, video_stream: VideoStream, desc: str = "Caching") -> None:
+    def __init__(self, video_stream: VideoStream, desc: str = "Caching", compact_rgb: bool = True) -> None:
         self._frame_size = video_stream.frame_size()
         self._fps = video_stream.fps()
         self._name = video_stream.name()
@@ -365,6 +373,7 @@ class CachedVideoStream(VideoStream):
         self.iterator: Iterator[VideoFrame] | None = iter(video_stream)
         self.data: list[VideoFrame] = []
         self.desc = desc
+        self.compact_rgb = compact_rgb
 
     def fps(self) -> float:
         return self._fps
@@ -391,7 +400,7 @@ class CachedVideoStream(VideoStream):
         for _ in itr:
             assert self.iterator is not None
             try:
-                self.data.append(next(self.iterator).cpu())
+                self.data.append(next(self.iterator).cpu(compact_rgb=self.compact_rgb))
             except StopIteration:
                 logger.warning(
                     "Iterator is exhausted -- expecting total frames = %d, stopped at %d",

--- a/vipe/utils/io.py
+++ b/vipe/utils/io.py
@@ -16,6 +16,7 @@
 import logging
 import tempfile
 import zipfile
+from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterator, cast
@@ -277,6 +278,17 @@ def save_depth_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStrea
                     z.write(f.name, f"{frame_idx:05d}.exr")
 
 
+def _write_depth_exr(z: zipfile.ZipFile, frame_idx: int, metric_depth: np.ndarray) -> None:
+    height, width = metric_depth.shape
+    header = OpenEXR.Header(width, height)
+    header["channels"] = {"Z": Imath.Channel(Imath.PixelType(Imath.PixelType.HALF))}
+    with tempfile.NamedTemporaryFile(suffix=".exr") as f:
+        exr = OpenEXR.OutputFile(f.name, header)
+        exr.writePixels({"Z": metric_depth.astype(np.float16).tobytes()})
+        exr.close()
+        z.write(f.name, f"{frame_idx:05d}.exr")
+
+
 def read_depth_artifacts(zip_file_path: Path) -> Iterator[tuple[int, torch.Tensor]]:
     """
     Read metric depth from zipped exr files.
@@ -340,40 +352,66 @@ def read_instance_phrases(instance_phrase_path: Path) -> dict[int, str]:
 
 def save_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream) -> None:
     """
-    Save each attribute independently.
+    Save each attribute in one pass over the stream.
     """
 
-    # Save OpenCV cam2world matrices as 4x4 matrix in npz file
-    save_pose_artifacts(out_path, cached_final_stream)
-
-    # Save intrinsics as [fx, fy, cx, cy] in npz file
-    save_intrinsics_artifacts(out_path, cached_final_stream)
-
-    # Save original RGB as H264-encoded video.
-    save_rgb_artifacts(out_path, cached_final_stream)
-
-    # Save metric depth as zipped exr files.
-    save_depth_artifacts(out_path, cached_final_stream)
-
-    # Save Instance mask as zipped PNG files.
-    instance_list = [
-        (frame_idx, frame_data.instance)
-        for frame_idx, frame_data in enumerate(cached_final_stream)
-        if frame_data.instance is not None
-    ]
-    if len(instance_list) > 0:
-        out_path.mask_path.parent.mkdir(exist_ok=True, parents=True)
-        with zipfile.ZipFile(out_path.mask_path, "w", zipfile.ZIP_DEFLATED) as z:
-            for frame_idx, instance in instance_list:
-                _, mask_buffer = cv2.imencode(".png", instance.cpu().numpy().astype(np.uint8))
-                z.writestr(f"{frame_idx:05d}.png", mask_buffer.tobytes())
-
-    # Save Instance phrases as txt file.
+    pose_list = []
+    intrinsics_list = []
+    camera_type_list = []
     instance_phrases_combined = {}
-    for frame_data in cached_final_stream:
-        assert isinstance(frame_data, VideoFrame)
-        if frame_data.instance_phrases is not None:
-            instance_phrases_combined.update(frame_data.instance_phrases)
+
+    with ExitStack() as stack, VideoWriter(out_path.rgb_path, cached_final_stream.fps()) as rgb_writer:
+        depth_zip: zipfile.ZipFile | None = None
+        mask_zip: zipfile.ZipFile | None = None
+
+        for frame_idx, frame_data in enumerate(cached_final_stream):
+            assert isinstance(frame_data, VideoFrame)
+
+            if frame_data.pose is not None:
+                pose_list.append((frame_idx, frame_data.pose.matrix().cpu().numpy()))
+
+            if frame_data.intrinsics is not None:
+                intrinsics_list.append((frame_idx, frame_data.intrinsics.cpu().numpy()))
+
+            if frame_data.camera_type is not None:
+                camera_type_list.append((frame_idx, frame_data.camera_type))
+
+            rgb_writer.write((frame_data.rgb.cpu().numpy() * 255).astype(np.uint8))
+
+            if frame_data.metric_depth is not None:
+                if depth_zip is None:
+                    out_path.depth_path.parent.mkdir(exist_ok=True, parents=True)
+                    depth_zip = stack.enter_context(zipfile.ZipFile(out_path.depth_path, "w", zipfile.ZIP_DEFLATED))
+                _write_depth_exr(depth_zip, frame_idx, frame_data.metric_depth.cpu().numpy())
+
+            if frame_data.instance is not None:
+                if mask_zip is None:
+                    out_path.mask_path.parent.mkdir(exist_ok=True, parents=True)
+                    mask_zip = stack.enter_context(zipfile.ZipFile(out_path.mask_path, "w", zipfile.ZIP_DEFLATED))
+                _, mask_buffer = cv2.imencode(".png", frame_data.instance.cpu().numpy().astype(np.uint8))
+                mask_zip.writestr(f"{frame_idx:05d}.png", mask_buffer.tobytes())
+
+            if frame_data.instance_phrases is not None:
+                instance_phrases_combined.update(frame_data.instance_phrases)
+
+    if len(pose_list) > 0:
+        pose_data = np.stack([pose for _, pose in pose_list], axis=0)
+        pose_inds = np.array([frame_idx for frame_idx, _ in pose_list])
+        out_path.pose_path.parent.mkdir(exist_ok=True, parents=True)
+        np.savez(out_path.pose_path, data=pose_data, inds=pose_inds)
+
+    if len(intrinsics_list) > 0:
+        intrinsics_data = np.stack([intrinsics for _, intrinsics in intrinsics_list], axis=0)
+        intrinsics_inds = np.array([frame_idx for frame_idx, _ in intrinsics_list])
+        out_path.intrinsics_path.parent.mkdir(exist_ok=True, parents=True)
+        np.savez(out_path.intrinsics_path, data=intrinsics_data, inds=intrinsics_inds)
+
+    if len(camera_type_list) > 0:
+        out_path.camera_type_path.parent.mkdir(exist_ok=True, parents=True)
+        with out_path.camera_type_path.open("w") as f:
+            for frame_idx, camera_type_data in camera_type_list:
+                f.write(f"{frame_idx}: {camera_type_data.name}\n")
+
     if len(instance_phrases_combined) > 0:
         out_path.mask_phrase_path.parent.mkdir(exist_ok=True, parents=True)
         with out_path.mask_phrase_path.open("w") as f:


### PR DESCRIPTION
## Summary

- Store cached RGB frames as `uint8` on CPU and restore float RGB when moving cached frames back to CUDA.
- Make `vipe infer` stream inputs by default, with `--cache-input` as an opt-in fallback for malformed videos.
- Write artifacts in a single stream pass and avoid output-stream caches unless visualization or returned streams require replay.
- Compact the default VDA frame staging path and add regression tests for single-pass artifact writing and compact cache storage.

Related issues: #44, #61, #66, #68.

## Long-video RAM benchmark

Benchmark video: `/tmp/vipe-ram-bench/dog-488f.mp4`, generated by looping `assets/examples/dog-example.mp4` to 488 frames at 1280x720, duration 16.28s. Measurements used `/usr/bin/time -v`.

| Mode | Frames | Cached RGB | Max RSS | Wall time |
|---|---:|---:|---:|---:|
| Stream, no cache | 488 | 0 | 0.87 GiB | 3.46s |
| Old float cache simulation | 488 | 5146.9 MiB | 5.78 GiB | 4.91s |
| New compact cache | 488 | 1286.7 MiB | 2.48 GiB | 6.99s |

End-to-end checks on the same synthesized clip:

| Run | Config | Frames | Max RSS | Wall time | Output validation |
|---|---|---:|---:|---:|---|
| Pose/artifacts | no instance, no post depth, no viz | 488 | 4.52 GiB | 55.55s | RGB, pose, intrinsics all 488 frames |
| Depth-enabled | default `adaptive_unidepth-l_svda`, instance off, no viz | 244 | 8.62 GiB | 1m13.56s | RGB, pose, intrinsics, depth all 244 frames |

The default VDA path is still the heavier mode because it stages whole-video depth alignment data, but cached RGB retention is reduced 4x and the artifact path no longer forces a full post-depth output cache.

## Validation

- `uv run --group dev ruff check vipe/streams/base.py vipe/pipeline/processors.py vipe/priors/depth/videodepthanything/video_depth.py vipe/cli/main.py vipe/utils/io.py vipe/pipeline/default.py vipe/pipeline/panorama.py tests/test_memory_usage.py`
- `uv run --group dev ruff format --check vipe/streams/base.py vipe/pipeline/processors.py vipe/priors/depth/videodepthanything/video_depth.py vipe/cli/main.py vipe/utils/io.py vipe/pipeline/default.py vipe/pipeline/panorama.py tests/test_memory_usage.py`
- `uv run --group dev mypy vipe/streams/base.py vipe/pipeline/default.py vipe/pipeline/panorama.py vipe/cli/main.py vipe/utils/io.py vipe/pipeline/processors.py`
- `uv run --group dev pytest` -> 31 passed
