### PR TITLE
Quick fix for TrackAnythingProcessor mask_phrases leak

### DIFF
--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -119,7 +119,8 @@ class TrackAnythingProcessor(StreamProcessor):
         sam_run_gap: int = 30,
         mask_expand: int = 5,
     ) -> None:
-        self.mask_phrases = mask_phrases
+        # Defensive copy: prevent mutation of caller's list
+        self.mask_phrases = list(mask_phrases)
         self.sam_run_gap = sam_run_gap
         self.add_sky = add_sky
 


### PR DESCRIPTION
One-line change to guard against list argument mutation.

There is an accidental state accumulation which causes error after long running pipeline:
```
vipe/pipeline/processors.py:122-127:
class TrackAnythingProcessor:
    def __init__(self, mask_phrases, add_sky, ...):
        self.mask_phrases = mask_phrases        # reference to caller's list
        self.add_sky = add_sky
        if self.add_sky:
            self.mask_phrases.append(VideoFrame.SKY_PROMPT)   # mutates input
```
And the caller at vipe/pipeline/default.py:DefaultAnnotationPipeline.run constructs a fresh TrackAnythingProcessor(self.init_cfg.instance.phrases, ...) on every call to pipeline.run(stream_file) (i.e. per clip), passing the same self.init_cfg.instance.phrases list reference each time. Each clip the worker processes appends another "sky" to that list. Eventually it exceeds the 256 token limit.