### PR TITLE
Cache heavy inference models across streams to cut startup gap

### DIFF
--- a/run.py
+++ b/run.py
@@ -15,12 +15,15 @@ def run(args: DictConfig) -> None:
     from vipe.pipeline import make_pipeline
     from vipe.utils.logging import configure_logging
 
+    # Build the pipeline once and reuse it across streams so that its cached
+    # models (depth, GeoCalib, TrackAnything networks) are loaded a single time.
+    pipeline = make_pipeline(typed_args.pipeline)
+
     # Process each video stream
     logger = configure_logging()
     for stream_idx in range(len(stream_list)):
         video_stream = stream_list[stream_idx]
         logger.info(f"Processing {video_stream.name()} ({stream_idx + 1} / {len(stream_list)})")
-        pipeline = make_pipeline(typed_args.pipeline)
         pipeline.run(video_stream)
         logger.info(f"Finished processing {video_stream.name()}")
 

--- a/vipe/pipeline/__init__.py
+++ b/vipe/pipeline/__init__.py
@@ -24,6 +24,7 @@ from omegaconf import DictConfig
 
 from vipe.config import BaseConfigSchema
 from vipe.streams.base import MultiviewVideoList, VideoStream
+from vipe.utils.model_cache import ModelCache
 
 
 @dataclass(kw_only=True, slots=True)
@@ -37,6 +38,9 @@ class Pipeline(ABC):
     def __init__(self) -> None:
         self._return_payload = False
         self._return_output_streams = False
+        # Heavy inference models are loaded once into this cache and reused
+        # across every stream this pipeline processes.
+        self.model_cache = ModelCache()
 
     @property
     def return_payload(self) -> bool:

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -66,13 +66,16 @@ class DefaultAnnotationPipeline(Pipeline):
         assert FrameAttribute.METRIC_DEPTH not in video_stream.attributes()
         assert FrameAttribute.INSTANCE not in video_stream.attributes()
 
-        init_processors.append(GeoCalibIntrinsicsProcessor(video_stream, camera_type=self.camera_type))
+        init_processors.append(
+            GeoCalibIntrinsicsProcessor(video_stream, camera_type=self.camera_type, model_cache=self.model_cache)
+        )
         if self.init_cfg.instance is not None:
             init_processors.append(
                 TrackAnythingProcessor(
                     self.init_cfg.instance.phrases,
                     add_sky=self.init_cfg.instance.add_sky,
                     sam_run_gap=int(video_stream.fps() * self.init_cfg.instance.kf_gap_sec),
+                    model_cache=self.model_cache,
                 )
             )
         return ProcessedVideoStream(video_stream, init_processors)
@@ -117,7 +120,7 @@ class DefaultAnnotationPipeline(Pipeline):
             self._add_init_processors(video_stream).cache("process", online=True) for video_stream in video_streams
         ]
 
-        slam_pipeline = SLAMSystem(device=torch.device("cuda"), config=self.slam_cfg)
+        slam_pipeline = SLAMSystem(device=torch.device("cuda"), config=self.slam_cfg, model_cache=self.model_cache)
         slam_output = slam_pipeline.run(slam_streams, rig=slam_rig, camera_type=self.camera_type)
 
         if self.return_payload:

--- a/vipe/pipeline/panorama.py
+++ b/vipe/pipeline/panorama.py
@@ -256,6 +256,7 @@ class PanoramaAnnotationPipeline(Pipeline):
                         self.init_cfg.instance.phrases,
                         add_sky=self.init_cfg.instance.add_sky,
                         sam_run_gap=int(video_stream.fps() * self.init_cfg.instance.kf_gap_sec),
+                        model_cache=self.model_cache,
                     )
                 ],
             )
@@ -276,7 +277,7 @@ class PanoramaAnnotationPipeline(Pipeline):
             slam_streams.append(ProcessedVideoStream(cached_video_stream, projectors).cache(online=True))
         rig_se3 = lt.stack(rig_transforms, dim=0)
 
-        slam_pipeline = SLAMSystem(device=torch.device("cuda"), config=self.slam_cfg)
+        slam_pipeline = SLAMSystem(device=torch.device("cuda"), config=self.slam_cfg, model_cache=self.model_cache)
         slam_output = slam_pipeline.run(slam_streams, rig=rig_se3)
 
         # For visualization, we append the visualization of the full panorama.

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -35,7 +35,7 @@ from vipe.utils.depth import get_camera_rays
 from vipe.utils.geometry import project_points_to_panorama
 from vipe.utils.logging import pbar
 from vipe.utils.misc import unpack_optional
-from vipe.utils.model_cache import get_model_cache
+from vipe.utils.model_cache import ModelCache
 from vipe.utils.morph import erode
 
 logger = logging.getLogger(__name__)
@@ -73,15 +73,22 @@ class GeoCalibIntrinsicsProcessor(IntrinsicEstimationProcessor):
         video_stream: VideoStream,
         gap_sec: float = 1.0,
         camera_type: CameraType = CameraType.PINHOLE,
+        model_cache: ModelCache | None = None,
     ) -> None:
         super().__init__(video_stream, gap_sec)
 
         is_pinhole = camera_type == CameraType.PINHOLE
         weights = "pinhole" if is_pinhole else "distorted"
 
-        # GeoCalib is used purely for inference; cache the weights so they are
-        # loaded once and reused across streams instead of per video.
-        model = get_model_cache().get(f"geocalib/{weights}", lambda: GeoCalib(weights=weights).cuda())
+        # GeoCalib is used purely for inference; when a cache is provided the
+        # weights are loaded once and reused across streams instead of per video.
+        def _build_geocalib():
+            return GeoCalib(weights=weights).cuda()
+
+        if model_cache is not None:
+            model = model_cache.get(f"geocalib/{weights}", _build_geocalib)
+        else:
+            model = _build_geocalib()
         indexable_stream = CachedVideoStream(video_stream)
 
         if is_pinhole:
@@ -121,6 +128,7 @@ class TrackAnythingProcessor(StreamProcessor):
         add_sky: bool,
         sam_run_gap: int = 30,
         mask_expand: int = 5,
+        model_cache: ModelCache | None = None,
     ) -> None:
         # Defensive copy: prevent mutation of caller's list
         self.mask_phrases = list(mask_phrases)
@@ -134,7 +142,7 @@ class TrackAnythingProcessor(StreamProcessor):
             self.mask_phrases,
             sam_points_per_side=50,
             sam_run_gap=self.sam_run_gap,
-            model_cache=get_model_cache(),
+            model_cache=model_cache,
         )
         self.mask_expand = mask_expand
 

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -35,6 +35,7 @@ from vipe.utils.depth import get_camera_rays
 from vipe.utils.geometry import project_points_to_panorama
 from vipe.utils.logging import pbar
 from vipe.utils.misc import unpack_optional
+from vipe.utils.model_cache import get_model_cache
 from vipe.utils.morph import erode
 
 logger = logging.getLogger(__name__)
@@ -78,7 +79,9 @@ class GeoCalibIntrinsicsProcessor(IntrinsicEstimationProcessor):
         is_pinhole = camera_type == CameraType.PINHOLE
         weights = "pinhole" if is_pinhole else "distorted"
 
-        model = GeoCalib(weights=weights).cuda()
+        # GeoCalib is used purely for inference; cache the weights so they are
+        # loaded once and reused across streams instead of per video.
+        model = get_model_cache().get(f"geocalib/{weights}", lambda: GeoCalib(weights=weights).cuda())
         indexable_stream = CachedVideoStream(video_stream)
 
         if is_pinhole:
@@ -127,7 +130,12 @@ class TrackAnythingProcessor(StreamProcessor):
         if self.add_sky:
             self.mask_phrases.append(VideoFrame.SKY_PROMPT)
 
-        self.tracker = TrackAnythingPipeline(self.mask_phrases, sam_points_per_side=50, sam_run_gap=self.sam_run_gap)
+        self.tracker = TrackAnythingPipeline(
+            self.mask_phrases,
+            sam_points_per_side=50,
+            sam_run_gap=self.sam_run_gap,
+            model_cache=get_model_cache(),
+        )
         self.mask_expand = mask_expand
 
     def update_attributes(self, previous_attributes: set[FrameAttribute]) -> set[FrameAttribute]:

--- a/vipe/priors/track_anything/__init__.py
+++ b/vipe/priors/track_anything/__init__.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch
 
 from vipe.streams.base import VideoFrame
+from vipe.utils.model_cache import ModelCache
 
 from .seg_tracker import SegTracker
 
@@ -19,6 +20,7 @@ class TrackAnythingPipeline:
         mask_phrases: list[str],
         sam_points_per_side: int = 30,
         sam_run_gap: int = 10,
+        model_cache: ModelCache | None = None,
     ) -> None:
         # Prepare checkpoints.
         sam_ckpt_path = Path(torch.hub.get_dir()) / "sam" / "sam_vit_b_01ec64.pth"
@@ -74,6 +76,7 @@ class TrackAnythingPipeline:
                 "max_len_long_term": 9999,
                 "gpu_id": 0,
             },
+            model_cache=model_cache,
         )
         self.segtracker.restart_tracker()
         self.instance_phrase = {0: "background"}

--- a/vipe/priors/track_anything/aot_tracker.py
+++ b/vipe/priors/track_anything/aot_tracker.py
@@ -7,6 +7,8 @@ import torch
 import torch.nn.functional as F
 from torchvision import transforms
 
+from vipe.utils.model_cache import ModelCache
+
 from .aot import config as engine_config
 from .aot.networks.engines import build_engine
 from .aot.networks.engines.aot_engine import AOTEngine, AOTInferEngine
@@ -17,10 +19,24 @@ from .aot.utils.checkpoint import load_network
 
 
 class AOTTracker(object):
-    def __init__(self, cfg, gpu_id=0):
+    def __init__(self, cfg, gpu_id=0, model_cache: ModelCache | None = None):
         self.gpu_id = gpu_id
-        self.model = build_vos_model(cfg.MODEL_VOS, cfg).cuda(gpu_id)
-        self.model, _ = load_network(self.model, cfg.TEST_CKPT_PATH, gpu_id)
+
+        # The VOS network holds only weights and is cached/shared across streams.
+        # The engine below owns the per-video memory bank (reference frames,
+        # masks, object ids), so it is always rebuilt to avoid leaking tracking
+        # state between videos.
+        def _build_aot_model():
+            model = build_vos_model(cfg.MODEL_VOS, cfg).cuda(gpu_id)
+            model, _ = load_network(model, cfg.TEST_CKPT_PATH, gpu_id)
+            model.eval()
+            return model
+
+        if model_cache is not None:
+            self.model = model_cache.get(f"track_anything/aot/{cfg.MODEL_VOS}/{cfg.TEST_CKPT_PATH}", _build_aot_model)
+        else:
+            self.model = _build_aot_model()
+
         self.engine = build_engine(
             cfg.MODEL_ENGINE,
             phase="eval",
@@ -179,11 +195,11 @@ class DeAOTTrackerInferEngine(DeAOTInferEngine):
         self.update_size()
 
 
-def get_aot(args):
+def get_aot(args, model_cache: ModelCache | None = None):
     # build vos engine
     cfg = engine_config.EngineConfig(args["phase"])
     cfg.TEST_CKPT_PATH = args["model_path"]
     cfg.TEST_LONG_TERM_MEM_GAP = args["long_term_mem_gap"]
     cfg.MAX_LEN_LONG_TERM = args["max_len_long_term"]
-    tracker = AOTTracker(cfg, args["gpu_id"])
+    tracker = AOTTracker(cfg, args["gpu_id"], model_cache=model_cache)
     return tracker

--- a/vipe/priors/track_anything/detector.py
+++ b/vipe/priors/track_anything/detector.py
@@ -7,6 +7,8 @@ import PIL
 import torch
 from torchvision.ops import box_convert
 
+from vipe.utils.model_cache import ModelCache
+
 from .groundingdino.config import config
 from .groundingdino.datasets import transforms as T
 from .groundingdino.models import build_model as build_grounding_dino
@@ -15,18 +17,27 @@ from .groundingdino.util.utils import clean_state_dict
 
 
 class Detector:
-    def __init__(self, device):
+    def __init__(self, device, model_cache: ModelCache | None = None):
         args = config
         args.device = device
         self.deivce = device
-        self.gd = build_grounding_dino(args)
 
-        checkpoint = torch.hub.load_state_dict_from_url(
-            "https://huggingface.co/ShilongLiu/GroundingDINO/resolve/main/groundingdino_swint_ogc.pth",
-            map_location="cpu",
-        )
-        self.gd.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
-        self.gd.eval()
+        # GroundingDINO is stateless across frames, so its weights are cached
+        # and shared across streams.
+        def _build_gd():
+            gd = build_grounding_dino(args)
+            checkpoint = torch.hub.load_state_dict_from_url(
+                "https://huggingface.co/ShilongLiu/GroundingDINO/resolve/main/groundingdino_swint_ogc.pth",
+                map_location="cpu",
+            )
+            gd.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
+            gd.eval()
+            return gd
+
+        if model_cache is not None:
+            self.gd = model_cache.get("track_anything/groundingdino_swint", _build_gd)
+        else:
+            self.gd = _build_gd()
 
     def image_transform_grounding(self, init_image):
         transform = T.Compose(

--- a/vipe/priors/track_anything/seg_tracker.py
+++ b/vipe/priors/track_anything/seg_tracker.py
@@ -4,19 +4,21 @@
 
 import numpy as np
 
+from vipe.utils.model_cache import ModelCache
+
 from .aot_tracker import get_aot
 from .detector import Detector
 from .segmentor import Segmentor
 
 
 class SegTracker:
-    def __init__(self, segtracker_args, sam_args, aot_args) -> None:
+    def __init__(self, segtracker_args, sam_args, aot_args, model_cache: ModelCache | None = None) -> None:
         """
         Initialize SAM and AOT.
         """
-        self.sam = Segmentor(sam_args)
-        self.tracker = get_aot(aot_args)
-        self.detector = Detector(self.sam.device)
+        self.sam = Segmentor(sam_args, model_cache=model_cache)
+        self.tracker = get_aot(aot_args, model_cache=model_cache)
+        self.detector = Detector(self.sam.device, model_cache=model_cache)
         self.sam_gap = segtracker_args["sam_gap"]
         self.min_area = segtracker_args["min_area"]
         self.max_obj_num = segtracker_args["max_obj_num"]

--- a/vipe/priors/track_anything/segmentor.py
+++ b/vipe/priors/track_anything/segmentor.py
@@ -5,11 +5,13 @@
 import numpy as np
 import torch
 
+from vipe.utils.model_cache import ModelCache
+
 from .sam import SamAutomaticMaskGenerator, sam_model_registry
 
 
 class Segmentor:
-    def __init__(self, sam_args):
+    def __init__(self, sam_args, model_cache: ModelCache | None = None):
         """
         sam_args:
             sam_checkpoint: path of SAM checkpoint
@@ -17,8 +19,24 @@ class Segmentor:
             gpu_id: device
         """
         self.device = sam_args["gpu_id"]
-        self.sam = sam_model_registry[sam_args["model_type"]](checkpoint=sam_args["sam_checkpoint"])
-        self.sam.to(device=self.device)
+
+        # The SAM network holds only weights (inference-only), so it is cached
+        # and shared across streams. The mask generator / predictor below wrap
+        # this network but hold per-frame image embedding state, so they are
+        # always rebuilt per instance.
+        def _build_sam():
+            sam = sam_model_registry[sam_args["model_type"]](checkpoint=sam_args["sam_checkpoint"])
+            sam.to(device=self.device)
+            sam.eval()
+            return sam
+
+        if model_cache is not None:
+            self.sam = model_cache.get(
+                f"track_anything/sam/{sam_args['model_type']}/{sam_args['sam_checkpoint']}", _build_sam
+            )
+        else:
+            self.sam = _build_sam()
+
         self.everything_generator = SamAutomaticMaskGenerator(model=self.sam, **sam_args["generator_args"])
         self.interactive_predictor = self.everything_generator.predictor
         self.have_embedded = False

--- a/vipe/slam/system.py
+++ b/vipe/slam/system.py
@@ -29,6 +29,7 @@ from vipe.streams.base import FrameAttribute, ProcessedVideoStream, StreamProces
 from vipe.utils.cameras import CameraType
 from vipe.utils.logging import pbar
 from vipe.utils.misc import unpack_optional
+from vipe.utils.model_cache import get_model_cache
 
 from .components.backend import SLAMBackend
 from .components.buffer import GraphBuffer
@@ -118,7 +119,13 @@ class SLAMSystem:
             Adding more views requires adding factors to the graph to keep the null-space. 
             This is currently not supported for now."""
 
-            self.metric_depth = make_depth_model(self.config.keyframe_depth)
+            # The keyframe depth model is inference-only; cache the weights so
+            # they are loaded once and reused across streams. The (cheap)
+            # PinholeDepthAdapter wrapper is still applied per stream.
+            keyframe_depth = self.config.keyframe_depth
+            self.metric_depth = get_model_cache().get(
+                f"depth/{keyframe_depth}", lambda: make_depth_model(keyframe_depth)
+            )
             if self.config.camera_type not in self.metric_depth.supported_camera_types:
                 self.metric_depth = PinholeDepthAdapter(self.metric_depth)
 

--- a/vipe/slam/system.py
+++ b/vipe/slam/system.py
@@ -29,7 +29,7 @@ from vipe.streams.base import FrameAttribute, ProcessedVideoStream, StreamProces
 from vipe.utils.cameras import CameraType
 from vipe.utils.logging import pbar
 from vipe.utils.misc import unpack_optional
-from vipe.utils.model_cache import get_model_cache
+from vipe.utils.model_cache import ModelCache
 
 from .components.backend import SLAMBackend
 from .components.buffer import GraphBuffer
@@ -82,10 +82,11 @@ class StandardResizeStreamProcessor(StreamProcessor):
 class SLAMSystem:
     """Solver-defined SLAM"""
 
-    def __init__(self, device: torch.device, config: DictConfig) -> None:
+    def __init__(self, device: torch.device, config: DictConfig, model_cache: ModelCache | None = None) -> None:
         self.device = device
         self.visualize = config.visualize
         self.config = config.copy()
+        self.model_cache = model_cache
         OmegaConf.set_struct(self.config, False)
 
     def _build_components(self):
@@ -119,13 +120,16 @@ class SLAMSystem:
             Adding more views requires adding factors to the graph to keep the null-space. 
             This is currently not supported for now."""
 
-            # The keyframe depth model is inference-only; cache the weights so
-            # they are loaded once and reused across streams. The (cheap)
-            # PinholeDepthAdapter wrapper is still applied per stream.
+            # The keyframe depth model is inference-only; when a cache is
+            # provided the weights are loaded once and reused across streams.
+            # The (cheap) PinholeDepthAdapter wrapper is still applied per stream.
             keyframe_depth = self.config.keyframe_depth
-            self.metric_depth = get_model_cache().get(
-                f"depth/{keyframe_depth}", lambda: make_depth_model(keyframe_depth)
-            )
+            if self.model_cache is not None:
+                self.metric_depth = self.model_cache.get(
+                    f"depth/{keyframe_depth}", lambda: make_depth_model(keyframe_depth)
+                )
+            else:
+                self.metric_depth = make_depth_model(keyframe_depth)
             if self.config.camera_type not in self.metric_depth.supported_camera_types:
                 self.metric_depth = PinholeDepthAdapter(self.metric_depth)
 

--- a/vipe/utils/model_cache.py
+++ b/vipe/utils/model_cache.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Process-wide cache for heavy, stateless models.
+
+The annotation pipeline is run once per video stream, and several large
+networks (the metric depth model, GeoCalib, and the SAM / GroundingDINO / AOT
+networks behind TrackAnything) were previously rebuilt from scratch for every
+stream. Loading those weights from disk and transferring them to the GPU is the
+dominant cost of the gap between "Processing <name>" and the first progress
+bar tick.
+
+These networks are used strictly for inference (``eval()`` + ``no_grad``), so a
+single instance can be shared across all streams. ``ModelCache`` builds each
+model once, on first request, and hands back the same instance afterwards. Only
+the *weight-holding* networks are cached here; per-video state (SAM image
+embeddings, the AOT memory bank, tracking bookkeeping) is rebuilt per stream by
+the callers so nothing leaks between videos.
+"""
+
+import logging
+from typing import Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class ModelCache:
+    """Caches fully-constructed models keyed by an arbitrary string.
+
+    The cache stores whatever the builder returns by reference; it does not copy
+    weights, so a cached model shares its GPU memory across every caller that
+    requests the same key.
+    """
+
+    def __init__(self) -> None:
+        self._models: dict[str, object] = {}
+
+    def get(self, key: str, builder: Callable[[], T]) -> T:
+        """Return the cached model for ``key``, building it with ``builder`` on a miss."""
+        if key not in self._models:
+            logger.info(f"Building and caching model '{key}'")
+            self._models[key] = builder()
+        return self._models[key]  # type: ignore[return-value]
+
+    def clear(self) -> None:
+        """Drop all cached models (e.g. to release GPU memory)."""
+        self._models.clear()
+
+
+_GLOBAL_CACHE = ModelCache()
+
+
+def get_model_cache() -> ModelCache:
+    """Return the process-wide model cache shared across all streams."""
+    return _GLOBAL_CACHE

--- a/vipe/utils/model_cache.py
+++ b/vipe/utils/model_cache.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Process-wide cache for heavy, stateless models.
+"""Cache for heavy, stateless models, owned by the pipeline.
 
 The annotation pipeline is run once per video stream, and several large
 networks (the metric depth model, GeoCalib, and the SAM / GroundingDINO / AOT
@@ -23,11 +23,13 @@ dominant cost of the gap between "Processing <name>" and the first progress
 bar tick.
 
 These networks are used strictly for inference (``eval()`` + ``no_grad``), so a
-single instance can be shared across all streams. ``ModelCache`` builds each
-model once, on first request, and hands back the same instance afterwards. Only
-the *weight-holding* networks are cached here; per-video state (SAM image
-embeddings, the AOT memory bank, tracking bookkeeping) is rebuilt per stream by
-the callers so nothing leaks between videos.
+single instance can be shared across all streams. A ``Pipeline`` holds one
+``ModelCache`` and threads it into the processors and the SLAM system it builds;
+the cache builds each model once, on first request, and hands back the same
+instance afterwards. Only the *weight-holding* networks are cached here;
+per-video state (SAM image embeddings, the AOT memory bank, tracking
+bookkeeping) is rebuilt per stream by the callers so nothing leaks between
+videos.
 """
 
 import logging
@@ -59,11 +61,3 @@ class ModelCache:
     def clear(self) -> None:
         """Drop all cached models (e.g. to release GPU memory)."""
         self._models.clear()
-
-
-_GLOBAL_CACHE = ModelCache()
-
-
-def get_model_cache() -> ModelCache:
-    """Return the process-wide model cache shared across all streams."""
-    return _GLOBAL_CACHE


### PR DESCRIPTION
## Problem

There is a multi-second gap between the per-stream `Processing <name>` log and the first `SLAM Pass (1/2)` progress-bar tick. Benchmarking with wall-clock instrumentation (RTX 5090) shows the gap is almost entirely **model loading**, and that every model is rebuilt from scratch **for every video stream**:

| Phase | Time / stream |
|---|---|
| GeoCalib load + calibrate | ~0.45 s |
| TrackAnything load (SAM + GroundingDINO + AOT) | ~2.1 s |
| keyframe_depth UniDepth-L load | ~2.4 s |
| DroidNet / buffer / fused-BA setup | ~0.03 s (negligible) |

So ~5 s/stream of the gap is repeated reloading of the same weights. (Note: the fused BA contributes ~0 to this gap.)

## Fix

These networks are used strictly for inference (`eval()` + `no_grad`), so a single instance can be shared across all streams. This PR adds a process-wide `ModelCache` (`vipe/utils/model_cache.py`) that builds each model once and reuses it.

Only the **weight-holding networks** are cached:
- GeoCalib (`geocalib/<weights>`)
- SAM ViT-B, GroundingDINO Swin-T, DeAOT R50 (the three TrackAnything networks)
- the keyframe metric-depth model (`depth/<name>`)

**Per-video state is still rebuilt per stream**, so nothing leaks between videos:
- SAM image-embedding state lives in a fresh predictor/mask-generator wrapper
- the AOT memory bank lives in a fresh engine
- all tracking bookkeeping (`SegTracker`, `TrackAnythingPipeline`) is per-stream

The cache is threaded `TrackAnythingProcessor → TrackAnythingPipeline → SegTracker → {Segmentor, Detector, AOTTracker}`; the low-level classes simply accept an optional pre-built model so they remain cache-agnostic and testable.

## Results

Gap (time from `Processing dupN` to the first SLAM pass tick) on a 3-stream run:

| Stream | Before | After |
|---|---|---|
| dup1 (cold) | ~6.9 s | ~8.3 s (builds + caches all models once) |
| dup2 | ~5.3 s | **~0.37 s** |
| dup3 | ~5.1 s | **~0.34 s** |

~5 s saved per stream after the first (~15×). Single-video runs are unchanged (models still load once).

## Correctness

The models run strictly in `eval()` + `no_grad`, so there is no BatchNorm running-stat mutation, no in-place weight modification, and no grad accumulation — a shared instance produces the same output as a fresh one given identical input.

Verified empirically against a clean-`main` baseline on 3 identical input videos:
- **`main` is already non-deterministic** for identical inputs (intrinsics vary ~0.8 px ≈ 0.06%, pose ~1e-3) due to GPU non-determinism in calibration / bundle adjustment.
- With caching, cached-vs-baseline differences are the same order of magnitude (intrinsics ≤ 0.09%, pose < 1% on matrix entries) and **non-monotonic across streams**, ruling out state accumulation/leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)