### PR TITLE
slam: parameterize fused-BA flow weight and add ba.fused=auto

### DIFF
--- a/configs/slam/default.yaml
+++ b/configs/slam/default.yaml
@@ -47,7 +47,10 @@ keyframe_depth: metric3d-small
 
 ba:
   dense_disp_alpha: 0.001
-  fused: false
+  # true | false | auto. auto enables the fused CUDA path when the pipeline layout is
+  # compatible (single-view pinhole, no robust kernel, no rig-rotation optimization,
+  # no sparse tracks).
+  fused: auto
   intrinsics_damping_scale: 1.0
   # robust kernel for dense-flow residual: null (L2) | huber | tukey | gnc_tls
   robust_kernel: null

--- a/csrc/slam_ext/geom_kernels.cu
+++ b/csrc/slam_ext/geom_kernels.cu
@@ -198,7 +198,8 @@ __global__ void projective_transform_kernel(
     const int itr,
     const bool compute_energy,
     const bool optimize_intrinsics,
-    const float intrinsics_scale) {
+    const float intrinsics_scale,
+    const float flow_weight) {
     const int block_id = blockIdx.x;
     const int thread_id = threadIdx.x;
 
@@ -318,8 +319,8 @@ __global__ void projective_transform_kernel(
         const float d = (Xj[2] < MIN_DEPTH) ? 0.0 : 1.0 / Xj[2];
         const float d2 = d * d;
 
-        float wu = (Xj[2] < MIN_DEPTH) ? 0.0 : .001 * weight[block_id][0][i][j];
-        float wv = (Xj[2] < MIN_DEPTH) ? 0.0 : .001 * weight[block_id][1][i][j];
+        float wu = (Xj[2] < MIN_DEPTH) ? 0.0 : flow_weight * weight[block_id][0][i][j];
+        float wv = (Xj[2] < MIN_DEPTH) ? 0.0 : flow_weight * weight[block_id][1][i][j];
 
         float Jf_u = 0.0f;
         float Jf_v = 0.0f;
@@ -1630,7 +1631,7 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
                                         const float lm, const float ep, const bool motion_only, const float alpha,
                                         const bool optimize_intrinsics, const float intrinsics_lm,
                                         const float intrinsics_ep, const float intrinsics_scale,
-                                        const bool compute_energy) {
+                                        const bool compute_energy, const float flow_weight) {
     CHECK_INPUT(targets);
     CHECK_INPUT(weights);
     CHECK_INPUT(poses);
@@ -1698,7 +1699,7 @@ std::vector<torch::Tensor> ba_cuda_impl(torch::Tensor poses, torch::Tensor disps
             Hff.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
             vf.packed_accessor32<float, 1, torch::RestrictPtrTraits>(),
             flow_energy.packed_accessor32<float, 2, torch::RestrictPtrTraits>(), itr, compute_energy,
-            optimize_intrinsics, intrinsics_scale);
+            optimize_intrinsics, intrinsics_scale, flow_weight);
 
         // pose x pose block
         SparseBlock A(t1 - t0, 6);
@@ -1830,7 +1831,7 @@ std::vector<torch::Tensor> ba_cuda(torch::Tensor poses, torch::Tensor disps, tor
                                    const float alpha) {
     torch::Tensor depth_active = torch::ones({disps.size(0)}, disps.options());
     return ba_cuda_impl(poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj, depth_active, t0, t1,
-                        iterations, lm, ep, motion_only, alpha, false, 1e-6f, 1e-6f, 1.0f, false);
+                        iterations, lm, ep, motion_only, alpha, false, 1e-6f, 1e-6f, 1.0f, false, 0.001f);
 }
 
 std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics,
@@ -1840,10 +1841,11 @@ std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor d
                                             const int iterations, const float lm, const float ep,
                                             const bool motion_only, const float alpha, const bool optimize_intrinsics,
                                             const float intrinsics_lm, const float intrinsics_ep,
-                                            const float intrinsics_scale, const bool compute_energy) {
+                                            const float intrinsics_scale, const bool compute_energy,
+                                            const float flow_weight) {
     return ba_cuda_impl(poses, disps, intrinsics, disps_sens, targets, weights, eta, ii, jj, depth_active, t0, t1,
                         iterations, lm, ep, motion_only, alpha, optimize_intrinsics, intrinsics_lm, intrinsics_ep,
-                        intrinsics_scale, compute_energy);
+                        intrinsics_scale, compute_energy, flow_weight);
 }
 
 torch::Tensor frame_distance_cuda(torch::Tensor poses, torch::Tensor disps, torch::Tensor intrinsics, torch::Tensor pi,

--- a/csrc/slam_ext/slam.cpp
+++ b/csrc/slam_ext/slam.cpp
@@ -34,7 +34,8 @@ std::vector<torch::Tensor> ba_extended_cuda(torch::Tensor poses, torch::Tensor d
                                             const int iterations, const float lm, const float ep,
                                             const bool motion_only, const float alpha, const bool optimize_intrinsics,
                                             const float intrinsics_lm, const float intrinsics_ep,
-                                            const float intrinsics_scale, const bool compute_energy);
+                                            const float intrinsics_scale, const bool compute_energy,
+                                            const float flow_weight);
 
 }  // namespace slam_ext
 
@@ -48,7 +49,7 @@ void pybind_slam_ext(py::module &m) {
           py::arg("weights"), py::arg("eta"), py::arg("ii"), py::arg("jj"), py::arg("depth_active"), py::arg("t0"),
           py::arg("t1"), py::arg("iterations"), py::arg("lm"), py::arg("ep"), py::arg("motion_only"),
           py::arg("alpha"), py::arg("optimize_intrinsics"), py::arg("intrinsics_lm"), py::arg("intrinsics_ep"),
-          py::arg("intrinsics_scale"), py::arg("compute_energy") = false);
+          py::arg("intrinsics_scale"), py::arg("compute_energy") = false, py::arg("flow_weight") = 0.001f);
     m.def("frame_distance", &slam_ext::frame_distance_cuda, "frame_distance");
     m.def("projmap", &slam_ext::projmap_cuda, "projmap");
     m.def("depth_filter", &slam_ext::depth_filter_cuda, "depth_filter");

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -220,7 +220,7 @@ Bundle-adjustment solver and robust loss options.
 | Field | Type | Default | Constraints | Description |
 | --- | --- | --- | --- | --- |
 | `dense_disp_alpha` | float | required | >= 0.0 | Weight for dense-disparity regularization during bundle adjustment. |
-| `fused` | bool | required | - | Use the fused CUDA bundle-adjustment path; unsupported layouts raise an error. |
+| `fused` | bool \| `auto` | required | - | Use the fused CUDA bundle-adjustment path. "auto" enables it automatically when the pipeline layout is compatible (single-view pinhole, no robust kernel, no rig-rotation optimization, no sparse tracks) and falls back to the generic solver otherwise; an explicit true forces the fused path and raises on unsupported layouts. |
 | `intrinsics_damping_scale` | float | required | > 0.0 | Multiplier for damping applied to optimized camera intrinsics. |
 | `robust_kernel` | `huber` \| `tukey` \| `gnc_tls` \| null | required | - | Robust loss for dense-flow residuals. Set to null for L2 residuals. |
 | `robust_kernel_threshold` | float | required | > 0.0 | Robust-kernel threshold in 1/8-resolution feature-map pixels. |

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,10 +134,41 @@ def test_parse_typed_config_accepts_fused_ba_override(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    ("overrides", "expected"),
+    [
+        ([], True),  # default pipeline: single-view pinhole, no robust kernel / rig rotation
+        (["pipeline.init.camera_type=mei"], False),  # non-pinhole camera
+        (["pipeline.slam.ba.robust_kernel=huber"], False),  # robust kernel
+        (["pipeline.slam.optimize_rig_rotation=true"], False),  # rig-rotation optimization
+        (["pipeline.slam.sparse_tracks.name=cuvslam"], False),  # sparse tracks (unsupported by fused)
+    ],
+)
+def test_auto_fused_ba_resolves_for_default_pipeline(tmp_path: Path, overrides: list[str], expected: bool) -> None:
+    config = parse_typed_config(
+        "default",
+        [*_base_overrides(tmp_path), "pipeline.slam.ba.fused=auto", *overrides],
+    )
+
+    fused = config.pipeline.slam.ba.fused
+    assert fused is expected
+    # "auto" must normalize to a concrete bool that survives the DictConfig round-trip.
+    assert config.pipeline.to_dictconfig().slam.ba.fused is expected
+
+
+def test_default_config_ships_auto_fused_ba(tmp_path: Path) -> None:
+    # The shipped default leaves ba.fused as auto, which resolves to fused for the
+    # default single-view pinhole pipeline.
+    config = parse_typed_config("default", _base_overrides(tmp_path))
+
+    assert config.pipeline.slam.ba.fused is True
+
+
+@pytest.mark.parametrize(
     "override",
     [
         "streams.frame_skip=0",
         "pipeline.slam.sparse_tracks.name=bad",
+        "pipeline.slam.ba.fused=maybe",
         "pipeline.output.viz_downsample=0",
         "+pipeline.output.unexpected=1",
     ],

--- a/tests/test_graph_buffer_fused_ba.py
+++ b/tests/test_graph_buffer_fused_ba.py
@@ -183,7 +183,6 @@ def _run_fused_bundle_adjustment(video, ba_inputs, *, motion_only: bool, limited
         optimize_intrinsics=optimize_intrinsics,
         optimize_rig_rotation=False,
         weight_dense_disp=0.001,
-        weight_tracks=0.001,
         verbose=False,
     )
     video.disps.clamp_(min=0.001)
@@ -200,9 +199,9 @@ class GraphBufferFusedBATest(unittest.TestCase):
         torch.testing.assert_close(actual.disps[:5], expected.disps[:5], atol=2e-4, rtol=2e-4)
         torch.testing.assert_close(actual.intrinsics, expected.intrinsics, atol=2e-4, rtol=2e-4)
 
-    def test_fused_ba_matches_generic_solver_with_intrinsics_limited_disp_and_sparse_tracks(self):
-        generic = _make_video(fused=False, sparse_tracks_enabled=True)
-        fused = _make_video(fused=True, sparse_tracks_enabled=True)
+    def test_fused_ba_matches_generic_solver_with_intrinsics_and_limited_disp(self):
+        generic = _make_video(fused=False, sparse_tracks_enabled=False)
+        fused = _make_video(fused=True, sparse_tracks_enabled=False)
         ba_inputs = _make_real_run_shaped_ba_inputs(generic)
 
         _run_generic_bundle_adjustment(
@@ -222,6 +221,30 @@ class GraphBufferFusedBATest(unittest.TestCase):
 
         self.assertTrue(used_fused_ba)
         self.assert_graph_buffers_close(fused, generic)
+
+    def test_fused_ba_errors_for_sparse_tracks_instead_of_falling_back(self):
+        fused = _make_video(fused=True, sparse_tracks_enabled=True)
+        ba_inputs = _make_real_run_shaped_ba_inputs(fused)
+        target, weight, disp_damping, ii, jj = ba_inputs
+
+        with self.assertRaisesRegex(RuntimeError, "sparse-track"):
+            fused.bundle_adjustment(
+                target=target.clone(),
+                weight=weight.clone(),
+                disp_damping=disp_damping.clone(),
+                ii=ii.clone(),
+                jj=jj.clone(),
+                t0=1,
+                t1=5,
+                n_iters=1,
+                pose_damping=1e-3,
+                pose_ep=0.1,
+                motion_only=False,
+                limited_disp=False,
+                optimize_intrinsics=False,
+                optimize_rig_rotation=False,
+                verbose=False,
+            )
 
     def test_fused_ba_matches_generic_solver_motion_only(self):
         generic = _make_video(fused=False, sparse_tracks_enabled=False)

--- a/vipe/config/pipeline.py
+++ b/vipe/config/pipeline.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
+from pydantic import model_validator
+
 from vipe.config.base_schema import BaseConfigSchema, Field
 from vipe.config.slam import SLAMConfig
 
@@ -102,6 +104,16 @@ class DefaultPipelineConfig(BaseConfigSchema):
     post: PostConfig = Field(description="Depth alignment and post-processing configuration.")
     output: OutputConfig = Field(description="Output artifact and visualization configuration.")
 
+    @model_validator(mode="after")
+    def normalize_fused_ba(self) -> DefaultPipelineConfig:
+        # Monocular pipeline: always single-view; the fused kernel additionally needs a
+        # pinhole camera model.
+        self.slam.ba.fused = self.slam.resolve_fused(
+            single_view=True,
+            pinhole=self.init.camera_type == "pinhole",
+        )
+        return self
+
 
 class PanoramaPipelineConfig(BaseConfigSchema):
     """Annotation pipeline for 360-degree panorama videos."""
@@ -114,6 +126,18 @@ class PanoramaPipelineConfig(BaseConfigSchema):
     slam: SLAMConfig = Field(description="SLAM and bundle-adjustment configuration for virtual views.")
     output: OutputConfig = Field(description="Output artifact and visualization configuration.")
     post: PostConfig = Field(description="Panorama depth estimation and post-processing configuration.")
+
+    @model_validator(mode="after")
+    def normalize_fused_ba(self) -> PanoramaPipelineConfig:
+        # Virtual views are pinhole, but multiple oriented views form a non-identity rig
+        # that the fused kernel cannot handle; only the degenerate single-view panorama
+        # (one centered, identity-rig view) is fused-eligible.
+        n_views = self.virtual.num_views + int(self.virtual.top) + int(self.virtual.bottom)
+        self.slam.ba.fused = self.slam.resolve_fused(
+            single_view=n_views == 1,
+            pinhole=True,
+        )
+        return self
 
 
 PipelineConfig = Annotated[DefaultPipelineConfig | PanoramaPipelineConfig, Field(discriminator="instance")]

--- a/vipe/config/slam.py
+++ b/vipe/config/slam.py
@@ -17,7 +17,12 @@ class BAConfig(BaseConfigSchema):
         ge=0.0,
         description="Weight for dense-disparity regularization during bundle adjustment.",
     )
-    fused: bool = Field(description="Use the fused CUDA bundle-adjustment path; unsupported layouts raise an error.")
+    fused: bool | Literal["auto"] = Field(
+        description='Use the fused CUDA bundle-adjustment path. "auto" enables it automatically when the '
+        "pipeline layout is compatible (single-view pinhole, no robust kernel, no rig-rotation optimization, "
+        "no sparse tracks) and falls back to the generic solver otherwise; an explicit true forces the fused "
+        "path and raises on unsupported layouts."
+    )
     intrinsics_damping_scale: float = Field(
         gt=0.0,
         description="Multiplier for damping applied to optimized camera intrinsics.",
@@ -115,3 +120,24 @@ class SLAMConfig(BaseConfigSchema):
         if value is not None and any(item < 0 for item in value):
             raise ValueError("cross_view_idx must contain non-negative view indices")
         return value
+
+    def resolve_fused(self, *, single_view: bool, pinhole: bool) -> bool:
+        """Resolve ``ba.fused`` to a concrete bool for the surrounding pipeline layout.
+
+        A plain bool is returned unchanged. ``"auto"`` enables the fused CUDA path only
+        when the layout satisfies every fused-kernel constraint that is knowable from
+        configuration: a single-view, pinhole, identity-rig graph optimized with an L2
+        (no robust kernel) loss, a fixed rig, and no sparse-track factors. Otherwise the
+        generic solver is selected. The pipeline supplies ``single_view`` / ``pinhole``
+        because the view count and camera model live outside the SLAM config.
+        """
+        fused = self.ba.fused
+        if isinstance(fused, bool):
+            return fused
+        return (
+            single_view
+            and pinhole
+            and self.ba.robust_kernel is None
+            and not self.optimize_rig_rotation
+            and self.sparse_tracks.name == "dummy"
+        )

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -378,7 +378,6 @@ class GraphBuffer:
         optimize_intrinsics: bool,
         optimize_rig_rotation: bool,
         weight_dense_disp: float,
-        weight_tracks: float,
         verbose: bool,
     ) -> None:
         def fail(reason: str) -> None:
@@ -388,13 +387,12 @@ class GraphBuffer:
             fail("it only supports single-view pinhole-camera graph buffers")
         if optimize_rig_rotation:
             fail("it does not support optimizing rig rotation")
+        if self.sparse_tracks.enabled:
+            fail("it does not support sparse-track factors")
         if t0 >= t1:
             fail("the active optimization range is empty")
         if target.shape[0] != ii.shape[0] or weight.shape[0] != ii.shape[0]:
             fail("target/weight edge counts do not match the graph edges")
-        # The DROID CUDA kernel applies the 0.001 dense-flow scale internally.
-        if weight_dense_disp != 0.001 or weight_tracks != 0.001:
-            fail("the configured dense-flow or sparse-track weights are unsupported")
 
         edge_mask = ii != jj
         if not torch.any(edge_mask):
@@ -410,26 +408,6 @@ class GraphBuffer:
             fail("it only supports identity rig extrinsics")
 
         ht, wd = self.height // 8, self.width // 8
-
-        if self.sparse_tracks.enabled:
-            view_inds = torch.zeros_like(ii)
-            sparse_target, sparse_weight = self.sparse_tracks.compute_dense_disp_target_weight(
-                source_view_inds=view_inds,
-                source_frame_inds=self.tstamp[ii],
-                target_view_inds=view_inds,
-                target_frame_inds=self.tstamp[jj],
-                image_size=(self.height, self.width),
-                dense_disp_size=(ht, wd),
-            )
-            sparse_target = sparse_target.flatten(1, 2)
-            sparse_weight = sparse_weight.flatten(1, 2)
-            combined_weight = weight + sparse_weight
-            combined_target = torch.where(
-                combined_weight > 0,
-                (weight * target + sparse_weight * sparse_target) / combined_weight.clamp_min(1e-12),
-                target,
-            )
-            target, weight = combined_target, combined_weight
 
         target = rearrange(target, "k (h w) c -> k c h w", h=ht, w=wd, c=2).contiguous()
         weight = rearrange(weight, "k (h w) c -> k c h w", h=ht, w=wd, c=2).contiguous()
@@ -475,6 +453,7 @@ class GraphBuffer:
                 1e-6 * intrinsics_damping_scale,
                 intrinsics_scale,
                 verbose,
+                weight_dense_disp,
             )
         except (AttributeError, TypeError) as exc:
             raise RuntimeError(
@@ -560,7 +539,6 @@ class GraphBuffer:
                 optimize_intrinsics,
                 optimize_rig_rotation,
                 weight_dense_disp,
-                weight_tracks,
                 verbose,
             )
             self.disps.clamp_(min=0.001)


### PR DESCRIPTION
## Summary

- **Parameterize the fused-BA dense-flow weight.** The fused DROID bundle-adjustment kernel previously hardcoded a `0.001` dense-flow weight scale. It's now a `flow_weight` kernel parameter (pybind default `0.001`, and the legacy `ba` entry point passes `0.001f`), so the fused path supports arbitrary dense-flow weights through the kernel rather than rescaling weights on the Python side.
- **Drop sparse-track support in the fused path.** `_fused_ba` now fails fast when sparse tracks are enabled instead of merging sparse and dense residuals. Merging changed the reported BA energy (by a per-pixel constant); the dense-only solve keeps the energy exact. The generic solver still supports sparse tracks.
- **Add `ba.fused=auto`.** The `fused` field accepts `true | false | auto`. During pydantic validation, `auto` is normalized to a concrete bool from the surrounding pipeline layout — single-view, pinhole, no robust kernel, no rig-rotation optimization, and no sparse tracks. The normalized value propagates to the runtime `DictConfig`. `auto` is now the shipped default, so compatible monocular-pinhole runs use the fused path automatically and incompatible layouts (multi-view/panorama, mei camera, robust kernel, rig rotation, sparse tracks) fall back to the generic solver.

## Notes

- The CUDA change requires rebuilding `vipe_ext` (or running with `VIPE_EXT_JIT=1`); the existing runtime-mismatch guard already prints that instruction.
- The legacy `ba` path and `ba_extended` default behavior are unchanged at `flow_weight=0.001`.

## Testing

- `pytest -q` (config resolution for `auto`, fused/generic parity, sparse-track rejection, kernel API).
- `ruff check .`, `mypy`, `scripts/generate_config_docs.py --check`, `mkdocs build --strict` all pass.
- Verified a default `vipe infer` run (no `ba.fused` override) exercises the fused BA path.