### PR TITLE
Keep Track Anything tensors on GPU

### DIFF
--- a/csrc/droid_net_ext/altcorr_kernel.cu
+++ b/csrc/droid_net_ext/altcorr_kernel.cu
@@ -161,6 +161,12 @@ __global__ void altcorr_index_forward_kernel(
     const int W2 = fmap2.size(3);
     const int C = fmap1.size(4);
 
+    // The +1 is shared-memory padding, not correctness: only columns
+    // 0..BLOCK_HW-1 are indexed. With BLOCK_HW = 32, same-column row
+    // accesses such as f1[tid % CHANNEL_STRIDE][k1] map a warp to one
+    // bank. A stride of 33 shifts each row by one bank, reducing conflicts
+    // in the tile load/store pattern; dot-product reads f1[k][tid] are not
+    // the main reason for the padding.
     __shared__ scalar_t f1[CHANNEL_STRIDE][BLOCK_HW + 1];
     __shared__ scalar_t f2[CHANNEL_STRIDE][BLOCK_HW + 1];
 

--- a/csrc/droid_net_ext/altcorr_kernel.cu
+++ b/csrc/droid_net_ext/altcorr_kernel.cu
@@ -161,8 +161,8 @@ __global__ void altcorr_index_forward_kernel(
     const int W2 = fmap2.size(3);
     const int C = fmap1.size(4);
 
-    __shared__ scalar_t f1[CHANNEL_STRIDE][BLOCK_HW];
-    __shared__ scalar_t f2[CHANNEL_STRIDE][BLOCK_HW];
+    __shared__ scalar_t f1[CHANNEL_STRIDE][BLOCK_HW + 1];
+    __shared__ scalar_t f2[CHANNEL_STRIDE][BLOCK_HW + 1];
 
     __shared__ float x2s[BLOCK_HW];
     __shared__ float y2s[BLOCK_HW];

--- a/vipe/priors/track_anything/__init__.py
+++ b/vipe/priors/track_anything/__init__.py
@@ -5,7 +5,6 @@
 from pathlib import Path
 
 import gdown
-import numpy as np
 import torch
 
 from vipe.streams.base import VideoFrame
@@ -94,11 +93,15 @@ class TrackAnythingPipeline:
             dict[int, str]: The phrases associated with each object id.
         """
 
-        # Convert to RGB numpy images
-        rgb_frame = (frame_data.rgb.cpu().numpy() * 255).astype(np.uint8)
+        if not frame_data.rgb.is_cuda:
+            raise RuntimeError("GPU Track Anything path requires frame.rgb to be a CUDA tensor")
+
+        rgb_frame = frame_data.rgb
 
         if self.frame_idx == 0:
-            pred_mask, _, pred_phrase = self.segtracker.detect_and_seg(rgb_frame, self.caption, **self.threshold_args)
+            pred_mask, _, pred_phrase = self.segtracker.detect_and_seg(
+                rgb_frame, self.caption, **self.threshold_args
+            )
             self.segtracker.add_reference(rgb_frame, pred_mask)
             self.instance_phrase.update(pred_phrase)
 
@@ -106,8 +109,8 @@ class TrackAnythingPipeline:
             seg_mask, _, pred_phrase = self.segtracker.detect_and_seg(rgb_frame, self.caption, **self.threshold_args)
             track_mask = self.segtracker.track(rgb_frame)
             new_obj_mask, seg_to_new_mapping = self.segtracker.find_new_objs(track_mask, seg_mask)
-            if np.sum(new_obj_mask > 0) > rgb_frame.shape[0] * rgb_frame.shape[1] * 0.4:
-                new_obj_mask = np.zeros_like(new_obj_mask)
+            if torch.sum(new_obj_mask > 0).item() > rgb_frame.shape[0] * rgb_frame.shape[1] * 0.4:
+                new_obj_mask = torch.zeros_like(new_obj_mask)
                 seg_to_new_mapping = {}
             pred_mask = track_mask + new_obj_mask
             pred_phrase = {seg_to_new_mapping[k]: v for k, v in pred_phrase.items() if k in seg_to_new_mapping}
@@ -119,7 +122,10 @@ class TrackAnythingPipeline:
 
         self.frame_idx += 1
 
-        pred_mask_unique = np.unique(pred_mask)
-        pred_phrase = {k: self.instance_phrase[k] for k in pred_mask_unique}
+        pred_mask_unique = torch.unique(pred_mask).detach().cpu().tolist()
+        pred_phrase = {
+            int(k): self.instance_phrase[int(k)] for k in pred_mask_unique if int(k) in self.instance_phrase
+        }
 
-        return torch.from_numpy(pred_mask).cuda(), pred_phrase
+        pred_mask = pred_mask.to(dtype=torch.uint8, device=rgb_frame.device)
+        return pred_mask, pred_phrase

--- a/vipe/priors/track_anything/__init__.py
+++ b/vipe/priors/track_anything/__init__.py
@@ -99,9 +99,7 @@ class TrackAnythingPipeline:
         rgb_frame = frame_data.rgb
 
         if self.frame_idx == 0:
-            pred_mask, _, pred_phrase = self.segtracker.detect_and_seg(
-                rgb_frame, self.caption, **self.threshold_args
-            )
+            pred_mask, _, pred_phrase = self.segtracker.detect_and_seg(rgb_frame, self.caption, **self.threshold_args)
             self.segtracker.add_reference(rgb_frame, pred_mask)
             self.instance_phrase.update(pred_phrase)
 
@@ -123,9 +121,7 @@ class TrackAnythingPipeline:
         self.frame_idx += 1
 
         pred_mask_unique = torch.unique(pred_mask).detach().cpu().tolist()
-        pred_phrase = {
-            int(k): self.instance_phrase[int(k)] for k in pred_mask_unique if int(k) in self.instance_phrase
-        }
+        pred_phrase = {int(k): self.instance_phrase[int(k)] for k in pred_mask_unique if int(k) in self.instance_phrase}
 
         pred_mask = pred_mask.to(dtype=torch.uint8, device=rgb_frame.device)
         return pred_mask, pred_phrase

--- a/vipe/priors/track_anything/aot_tracker.py
+++ b/vipe/priors/track_anything/aot_tracker.py
@@ -5,7 +5,7 @@
 import numpy as np
 import torch
 import torch.nn.functional as F
-from torchvision import transforms
+
 
 from vipe.utils.model_cache import ModelCache
 
@@ -14,7 +14,6 @@ from .aot.networks.engines import build_engine
 from .aot.networks.engines.aot_engine import AOTEngine, AOTInferEngine
 from .aot.networks.engines.deaot_engine import DeAOTEngine, DeAOTInferEngine
 from .aot.networks.models import build_vos_model
-from .aot.transforms import video_transforms as tr
 from .aot.utils.checkpoint import load_network
 
 
@@ -46,34 +45,80 @@ class AOTTracker(object):
             long_term_mem_gap=cfg.TEST_LONG_TERM_MEM_GAP,
             max_len_long_term=cfg.MAX_LEN_LONG_TERM,
         )
-
-        self.transform = transforms.Compose(
-            [
-                tr.MultiRestrictSize(
-                    cfg.TEST_MAX_SHORT_EDGE,
-                    cfg.TEST_MAX_LONG_EDGE,
-                    cfg.TEST_FLIP,
-                    cfg.TEST_MULTISCALE,
-                    cfg.MODEL_ALIGN_CORNERS,
-                ),
-                tr.MultiToTensor(),
-            ]
-        )
+        self.max_short_edge = cfg.TEST_MAX_SHORT_EDGE
+        self.max_long_edge = cfg.TEST_MAX_LONG_EDGE
+        self.flip = cfg.TEST_FLIP
+        self.multi_scale = cfg.TEST_MULTISCALE
+        self.align_corners = cfg.MODEL_ALIGN_CORNERS
+        self.max_stride = 16
 
         self.model.eval()
 
+    def _restricted_size(self, height: int, width: int) -> tuple[int, int]:
+        if len(self.multi_scale) != 1 or self.multi_scale[0] != 1:
+            raise NotImplementedError("GPU AOT path currently expects a single test scale of 1")
+        if self.flip:
+            raise NotImplementedError("GPU AOT path does not support test-time flip")
+
+        new_h, new_w = float(height), float(width)
+
+        if self.max_short_edge is not None:
+            short_edge = min(height, width)
+            if short_edge > self.max_short_edge:
+                scale = float(self.max_short_edge) / short_edge
+                new_h *= scale
+                new_w *= scale
+
+        if self.max_long_edge is not None:
+            long_edge = max(new_h, new_w)
+            if long_edge > self.max_long_edge:
+                scale = float(self.max_long_edge) / long_edge
+                new_h *= scale
+                new_w *= scale
+
+        new_h = int(new_h)
+        new_w = int(new_w)
+
+        if self.align_corners:
+            if (new_h - 1) % self.max_stride != 0:
+                new_h = int(np.around((new_h - 1) / self.max_stride) * self.max_stride + 1)
+            if (new_w - 1) % self.max_stride != 0:
+                new_w = int(np.around((new_w - 1) / self.max_stride) * self.max_stride + 1)
+        else:
+            if new_h % self.max_stride != 0:
+                new_h = int(np.around(new_h / self.max_stride) * self.max_stride)
+            if new_w % self.max_stride != 0:
+                new_w = int(np.around(new_w / self.max_stride) * self.max_stride)
+
+        return new_h, new_w
+
+    def _prepare_image_tensor(self, image: torch.Tensor) -> torch.Tensor:
+        if not isinstance(image, torch.Tensor):
+            raise TypeError("GPU AOT path requires image as a CUDA torch.Tensor")
+        if image.ndim != 3 or image.shape[-1] != 3:
+            raise ValueError(f"expected HWC RGB image tensor, got shape {tuple(image.shape)}")
+
+        device = torch.device(f"cuda:{self.gpu_id}")
+        input_is_uint8 = image.dtype == torch.uint8
+        image = image.to(device=device, dtype=torch.float32)
+        if input_is_uint8:
+            image = image / 255.0
+
+        image = image.permute(2, 0, 1).unsqueeze(0).contiguous()
+        new_h, new_w = self._restricted_size(image.shape[-2], image.shape[-1])
+        if (new_h, new_w) != tuple(image.shape[-2:]):
+            image = F.interpolate(image, size=(new_h, new_w), mode="bicubic", align_corners=False)
+
+        mean = image.new_tensor((0.485, 0.456, 0.406)).view(1, 3, 1, 1)
+        std = image.new_tensor((0.229, 0.224, 0.225)).view(1, 3, 1, 1)
+        return (image - mean) / std
+
     @torch.no_grad()
     def add_reference_frame(self, frame, mask, obj_nums, frame_step, incremental=False):
-        # mask = cv2.resize(mask, frame.shape[:2][::-1], interpolation = cv2.INTER_NEAREST)
-
-        sample = {
-            "current_img": frame,
-            "current_label": mask,
-        }
-
-        sample = self.transform(sample)
-        frame = sample[0]["current_img"].unsqueeze(0).float().cuda(self.gpu_id)
-        mask = sample[0]["current_label"].unsqueeze(0).float().cuda(self.gpu_id)
+        frame = self._prepare_image_tensor(frame)
+        if not isinstance(mask, torch.Tensor):
+            raise TypeError("GPU AOT path requires mask as a CUDA torch.Tensor")
+        mask = mask.to(device=frame.device, dtype=torch.float32)[None, None]
         _mask = F.interpolate(mask, size=frame.shape[-2:], mode="nearest")
 
         if incremental:
@@ -84,9 +129,7 @@ class AOTTracker(object):
     @torch.no_grad()
     def track(self, image):
         output_height, output_width = image.shape[0], image.shape[1]
-        sample = {"current_img": image}
-        sample = self.transform(sample)
-        image = sample[0]["current_img"].unsqueeze(0).float().cuda(self.gpu_id)
+        image = self._prepare_image_tensor(image)
         self.engine.match_propogate_one_frame(image)
         pred_logit = self.engine.decode_current_logits((output_height, output_width))
 

--- a/vipe/priors/track_anything/aot_tracker.py
+++ b/vipe/priors/track_anything/aot_tracker.py
@@ -6,7 +6,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-
 from vipe.utils.model_cache import ModelCache
 
 from .aot import config as engine_config

--- a/vipe/priors/track_anything/detector.py
+++ b/vipe/priors/track_anything/detector.py
@@ -5,6 +5,7 @@
 import numpy as np
 import PIL
 import torch
+import torch.nn.functional as F
 from torchvision.ops import box_convert
 
 from vipe.utils.model_cache import ModelCache
@@ -12,15 +13,16 @@ from vipe.utils.model_cache import ModelCache
 from .groundingdino.config import config
 from .groundingdino.datasets import transforms as T
 from .groundingdino.models import build_model as build_grounding_dino
-from .groundingdino.util.inference import predict
-from .groundingdino.util.utils import clean_state_dict
+from .groundingdino.util.inference import predict, preprocess_caption
+from .groundingdino.util.utils import clean_state_dict, get_best_phrase_from_logits
 
 
 class Detector:
     def __init__(self, device, model_cache: ModelCache | None = None):
         args = config
-        args.device = device
-        self.deivce = device
+        self.device = torch.device(f"cuda:{device}" if isinstance(device, int) else device)
+        args.device = str(self.device)
+        self.deivce = self.device
 
         # GroundingDINO is stateless across frames, so its weights are cached
         # and shared across streams.
@@ -31,6 +33,7 @@ class Detector:
                 map_location="cpu",
             )
             gd.load_state_dict(clean_state_dict(checkpoint["model"]), strict=False)
+            gd.to(self.device)
             gd.eval()
             return gd
 
@@ -38,6 +41,30 @@ class Detector:
             self.gd = model_cache.get("track_anything/groundingdino_swint", _build_gd)
         else:
             self.gd = _build_gd()
+
+    def _grounding_resize_size(
+        self,
+        height: int,
+        width: int,
+        size: int = 800,
+        max_size: int = 1333,
+    ) -> tuple[int, int]:
+        min_original_size = float(min((width, height)))
+        max_original_size = float(max((width, height)))
+        if max_original_size / min_original_size * size > max_size:
+            size = int(round(max_size * min_original_size / max_original_size))
+
+        if (width <= height and width == size) or (height <= width and height == size):
+            return height, width
+
+        if width < height:
+            output_width = size
+            output_height = int(size * height / width)
+        else:
+            output_height = size
+            output_width = int(size * width / height)
+
+        return output_height, output_width
 
     def image_transform_grounding(self, init_image):
         transform = T.Compose(
@@ -59,6 +86,26 @@ class Detector:
         image, _ = transform(init_image, None)  # 3, h, w
         return image
 
+    def image_transform_grounding_tensor(self, init_image: torch.Tensor) -> torch.Tensor:
+        if not isinstance(init_image, torch.Tensor):
+            raise TypeError("GPU GroundingDINO path requires image as a torch.Tensor")
+        if init_image.ndim != 3 or init_image.shape[-1] != 3:
+            raise ValueError(f"expected HWC RGB tensor, got shape {tuple(init_image.shape)}")
+
+        input_is_uint8 = init_image.dtype == torch.uint8
+        image = init_image.to(device=self.device, dtype=torch.float32)
+        if input_is_uint8:
+            image = image / 255.0
+
+        height, width = int(image.shape[0]), int(image.shape[1])
+        target_size = self._grounding_resize_size(height, width)
+        image = image.permute(2, 0, 1).unsqueeze(0).contiguous()
+        image = F.interpolate(image, size=target_size, mode="bilinear", align_corners=False, antialias=True)
+
+        mean = image.new_tensor((0.485, 0.456, 0.406)).view(1, 3, 1, 1)
+        std = image.new_tensor((0.229, 0.224, 0.225)).view(1, 3, 1, 1)
+        return ((image - mean) / std)[0]
+
     def transfer_boxes_format(self, boxes, height, width):
         boxes = boxes * torch.Tensor([width, height, width, height])
         boxes = box_convert(boxes=boxes, in_fmt="cxcywh", out_fmt="xyxy")
@@ -71,6 +118,38 @@ class Detector:
 
         transfered_boxes = np.array(transfered_boxes)
         return transfered_boxes
+
+    @torch.no_grad()
+    def run_grounding_tensor(
+        self,
+        origin_frame: torch.Tensor,
+        grounding_caption,
+        box_threshold,
+        text_threshold: float = 0.0,
+    ):
+        """
+        GPU-direct GroundingDINO path.
+        Returns the original frame shape and XYXY boxes as a CUDA tensor.
+        """
+        height, width = int(origin_frame.shape[0]), int(origin_frame.shape[1])
+        image_tensor = self.image_transform_grounding_tensor(origin_frame)
+        caption = preprocess_caption(caption=grounding_caption)
+
+        outputs = self.gd(image_tensor[None], captions=[caption])
+        prediction_logits = outputs["pred_logits"].sigmoid()[0]
+        prediction_boxes = outputs["pred_boxes"][0]
+
+        mask = prediction_logits.max(dim=1)[0] > box_threshold
+        logits = prediction_logits[mask]
+        boxes = prediction_boxes[mask]
+
+        tokenizer = self.gd.tokenizer
+        tokenized = tokenizer(caption)
+        phrases = [get_best_phrase_from_logits(logit, tokenized, tokenizer) for logit in logits]
+
+        boxes = boxes * boxes.new_tensor([width, height, width, height])
+        boxes = box_convert(boxes=boxes, in_fmt="cxcywh", out_fmt="xyxy")
+        return (height, width), boxes, phrases
 
     @torch.no_grad()
     def run_grounding(

--- a/vipe/priors/track_anything/sam/predictor.py
+++ b/vipe/priors/track_anything/sam/predictor.py
@@ -8,6 +8,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 
 from .modeling import Sam
 from .utils.transforms import ResizeLongestSide
@@ -59,6 +60,31 @@ class SamPredictor:
         ]
 
         self.set_torch_image(input_image_torch, image.shape[:2])
+
+    def set_image_tensor(self, image: torch.Tensor) -> None:
+        """
+        GPU-direct equivalent of set_image for an RGB HWC CUDA tensor.
+        Expects values in [0, 1] or [0, 255].
+        """
+        if not isinstance(image, torch.Tensor):
+            raise TypeError("set_image_tensor expects a torch.Tensor")
+        if image.ndim != 3 or image.shape[-1] != 3:
+            raise ValueError(f"expected HWC RGB tensor, got shape {tuple(image.shape)}")
+
+        original_size = tuple(image.shape[:2])
+        input_is_uint8 = image.dtype == torch.uint8
+        input_image = image.to(device=self.device, dtype=torch.float32)
+        if not input_is_uint8:
+            input_image = input_image * 255.0
+        input_image = input_image.permute(2, 0, 1).unsqueeze(0).contiguous()
+        target_size = self.transform.get_preprocess_shape(
+            original_size[0],
+            original_size[1],
+            self.model.image_encoder.img_size,
+        )
+        input_image = F.interpolate(input_image, size=target_size, mode="bilinear", align_corners=False, antialias=True)
+
+        self.set_torch_image(input_image, original_size)
 
     @torch.no_grad()
     def set_torch_image(

--- a/vipe/priors/track_anything/sam/predictor.py
+++ b/vipe/priors/track_anything/sam/predictor.py
@@ -55,9 +55,7 @@ class SamPredictor:
         # Transform the image to the form expected by the model
         input_image = self.transform.apply_image(image)
         input_image_torch = torch.as_tensor(input_image, device=self.device)
-        input_image_torch = input_image_torch.permute(2, 0, 1).contiguous()[
-            None, :, :, :
-        ]
+        input_image_torch = input_image_torch.permute(2, 0, 1).contiguous()[None, :, :, :]
 
         self.set_torch_image(input_image_torch, image.shape[:2])
 
@@ -158,32 +156,22 @@ class SamPredictor:
             a subsequent iteration as mask input.
         """
         if not self.is_image_set:
-            raise RuntimeError(
-                "An image must be set with .set_image(...) before mask prediction."
-            )
+            raise RuntimeError("An image must be set with .set_image(...) before mask prediction.")
 
         # Transform input prompts
         coords_torch, labels_torch, box_torch, mask_input_torch = None, None, None, None
         if point_coords is not None:
-            assert (
-                point_labels is not None
-            ), "point_labels must be supplied if point_coords is supplied."
+            assert point_labels is not None, "point_labels must be supplied if point_coords is supplied."
             point_coords = self.transform.apply_coords(point_coords, self.original_size)
-            coords_torch = torch.as_tensor(
-                point_coords, dtype=torch.float, device=self.device
-            )
-            labels_torch = torch.as_tensor(
-                point_labels, dtype=torch.int, device=self.device
-            )
+            coords_torch = torch.as_tensor(point_coords, dtype=torch.float, device=self.device)
+            labels_torch = torch.as_tensor(point_labels, dtype=torch.int, device=self.device)
             coords_torch, labels_torch = coords_torch[None, :, :], labels_torch[None, :]
         if box is not None:
             box = self.transform.apply_boxes(box, self.original_size)
             box_torch = torch.as_tensor(box, dtype=torch.float, device=self.device)
             box_torch = box_torch[None, :]
         if mask_input is not None:
-            mask_input_torch = torch.as_tensor(
-                mask_input, dtype=torch.float, device=self.device
-            )
+            mask_input_torch = torch.as_tensor(mask_input, dtype=torch.float, device=self.device)
             mask_input_torch = mask_input_torch[None, :, :, :]
 
         masks, iou_predictions, low_res_masks = self.predict_torch(
@@ -246,9 +234,7 @@ class SamPredictor:
             a subsequent iteration as mask input.
         """
         if not self.is_image_set:
-            raise RuntimeError(
-                "An image must be set with .set_image(...) before mask prediction."
-            )
+            raise RuntimeError("An image must be set with .set_image(...) before mask prediction.")
 
         if point_coords is not None:
             points = (point_coords, point_labels)
@@ -272,9 +258,7 @@ class SamPredictor:
         )
 
         # Upscale the masks to the original image resolution
-        masks = self.model.postprocess_masks(
-            low_res_masks, self.input_size, self.original_size
-        )
+        masks = self.model.postprocess_masks(low_res_masks, self.input_size, self.original_size)
 
         if not return_logits:
             masks = masks > self.model.mask_threshold
@@ -288,12 +272,8 @@ class SamPredictor:
         the embedding spatial dimension of SAM (typically C=256, H=W=64).
         """
         if not self.is_image_set:
-            raise RuntimeError(
-                "An image must be set with .set_image(...) to generate an embedding."
-            )
-        assert (
-            self.features is not None
-        ), "Features must exist if an image has been set."
+            raise RuntimeError("An image must be set with .set_image(...) to generate an embedding.")
+        assert self.features is not None, "Features must exist if an image has been set."
         return self.features
 
     @property

--- a/vipe/priors/track_anything/seg_tracker.py
+++ b/vipe/priors/track_anything/seg_tracker.py
@@ -3,6 +3,8 @@
 # Licensed under the AGPL-3.0 License. See THIRD_PARTY_LICENSES.md for details.
 
 import numpy as np
+import torch
+
 
 from vipe.utils.model_cache import ModelCache
 
@@ -47,10 +49,12 @@ class SegTracker:
         """
         Add objects in a mask for tracking.
         Arguments:
-            frame: numpy array (h,w,3)
-            mask: numpy array (h,w)
+            frame: CUDA tensor (h,w,3)
+            mask: CUDA tensor (h,w)
         """
-        self.reference_objs_list.append(np.unique(mask))
+        if not isinstance(mask, torch.Tensor):
+            raise TypeError("GPU Track Anything path requires reference mask as torch.Tensor")
+        self.reference_objs_list.append(torch.unique(mask).detach())
         self.curr_idx = self.get_obj_num()
         self.tracker.add_reference_frame(frame, mask, self.curr_idx, frame_step)
         self.curr_idx += 1
@@ -59,19 +63,22 @@ class SegTracker:
         """
         Track all known objects.
         Arguments:
-            frame: numpy array (h,w,3)
+            frame: CUDA tensor (h,w,3)
         Return:
-            origin_merged_mask: numpy array (h,w)
+            origin_merged_mask: CUDA tensor (h,w)
         """
-        pred_mask = self.tracker.track(frame)
+        pred_label = self.tracker.track(frame)
         if update_memory:
-            self.tracker.update_memory(pred_mask)
-        return pred_mask.squeeze(0).squeeze(0).detach().cpu().numpy().astype(np.uint8)
+            self.tracker.update_memory(pred_label)
+        return pred_label.squeeze(0).squeeze(0).to(torch.uint8)
 
     def get_tracking_objs(self):
         objs = set()
         for ref in self.reference_objs_list:
-            objs.update(set(ref))
+            if isinstance(ref, torch.Tensor):
+                objs.update(int(x) for x in ref.detach().cpu().tolist())
+            else:
+                objs.update(set(ref))
         objs = list(sorted(list(objs)))
         objs = [i for i in objs if i != 0]
         return objs
@@ -82,7 +89,7 @@ class SegTracker:
             return 0
         return int(max(objs))
 
-    def find_new_objs(self, track_mask, seg_mask):
+    def find_new_objs(self, track_mask: torch.Tensor, seg_mask: torch.Tensor):
         """
         Compare tracked results from AOT with segmented results from SAM. Select objects from background if they are not tracked.
         Arguments:
@@ -91,24 +98,24 @@ class SegTracker:
         Return:
             new_obj_mask: numpy array (h,w)
         """
-        new_obj_mask = (track_mask == 0) * seg_mask
-        new_obj_ids = np.unique(new_obj_mask)
+        new_obj_mask = torch.where(track_mask == 0, seg_mask, torch.zeros_like(seg_mask))
+        new_obj_ids = torch.unique(new_obj_mask)
         new_obj_ids = new_obj_ids[new_obj_ids != 0]
         seg_to_new_mapping = {}
         # obj_num = self.get_obj_num() + 1
         obj_num = self.curr_idx
         for idx in new_obj_ids:
-            new_obj_area = np.sum(new_obj_mask == idx)
-            obj_area = np.sum(seg_mask == idx)
+            new_obj_area = torch.sum(new_obj_mask == idx)
+            obj_area = torch.sum(seg_mask == idx)
             if (
-                new_obj_area / obj_area < self.min_new_obj_iou
-                or new_obj_area < self.min_area
+                (new_obj_area.float() / obj_area.float()).item() < self.min_new_obj_iou
+                or new_obj_area.item() < self.min_area
                 or obj_num > self.max_obj_num
             ):
                 new_obj_mask[new_obj_mask == idx] = 0
             else:
                 new_obj_mask[new_obj_mask == idx] = obj_num
-                seg_to_new_mapping[idx] = obj_num
+                seg_to_new_mapping[int(idx.item())] = obj_num
                 obj_num += 1
         return new_obj_mask, seg_to_new_mapping
 
@@ -131,9 +138,17 @@ class SegTracker:
 
         return refined_merged_mask
 
+    def add_mask_torch(self, interactive_mask: torch.Tensor) -> torch.Tensor:
+        if self.origin_merged_mask is None:
+            self.origin_merged_mask = torch.zeros(interactive_mask.shape, dtype=torch.uint8, device=interactive_mask.device)
+
+        refined_merged_mask = self.origin_merged_mask.clone()
+        refined_merged_mask[interactive_mask > 0] = self.curr_idx
+        return refined_merged_mask
+
     def detect_and_seg(
         self,
-        origin_frame: np.ndarray,
+        origin_frame: torch.Tensor,
         grounding_caption,
         box_threshold,
         text_threshold: float = 0.0,
@@ -151,20 +166,42 @@ class SegTracker:
         bc_mask = self.origin_merged_mask
         seg_phrase = {}
 
+        if not isinstance(origin_frame, torch.Tensor):
+            raise TypeError("GPU Track Anything path requires origin_frame as torch.Tensor")
+
         # get annotated_frame and boxes
-        annotated_frame_shape, boxes, phrases = self.detector.run_grounding(
+        annotated_frame_shape, boxes, phrases = self.detector.run_grounding_tensor(
             origin_frame, grounding_caption, box_threshold, text_threshold
         )
-        refined_merged_mask = np.zeros(annotated_frame_shape, dtype=np.uint8)
-        for i in range(len(boxes)):
-            bbox = boxes[i]
-            phrase = phrases[i]
-            if (bbox[1][0] - bbox[0][0]) * (bbox[1][1] - bbox[0][1]) > annotated_frame_shape[0] * annotated_frame_shape[
-                1
-            ] * box_size_threshold:
-                continue
-            interactive_mask = self.sam.segment_with_box(origin_frame, bbox, reset_image)[0]
-            refined_merged_mask = self.add_mask(interactive_mask)
+        refined_merged_mask = torch.zeros(annotated_frame_shape, dtype=torch.uint8, device=origin_frame.device)
+        if boxes.shape[0] > 0:
+            areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+            max_area = annotated_frame_shape[0] * annotated_frame_shape[1] * box_size_threshold
+            keep = areas <= max_area
+            keep_indices = torch.nonzero(keep, as_tuple=False).flatten()
+
+            if keep_indices.numel() > 0:
+                kept_boxes = boxes[keep_indices]
+                kept_phrases = [phrases[int(idx.item())] for idx in keep_indices]
+                interactive_masks = self.sam.segment_with_box_tensor(origin_frame, kept_boxes, reset_image)
+            else:
+                kept_phrases = []
+                interactive_masks = torch.empty(
+                    (0, annotated_frame_shape[0], annotated_frame_shape[1]),
+                    dtype=torch.uint8,
+                    device=origin_frame.device,
+                )
+
+        else:
+            kept_phrases = []
+            interactive_masks = torch.empty(
+                (0, annotated_frame_shape[0], annotated_frame_shape[1]),
+                dtype=torch.uint8,
+                device=origin_frame.device,
+            )
+
+        for interactive_mask, phrase in zip(interactive_masks, kept_phrases):
+            refined_merged_mask = self.add_mask_torch(interactive_mask)
             seg_phrase[self.curr_idx] = phrase
             self.update_origin_merged_mask(refined_merged_mask)
             self.curr_idx += 1

--- a/vipe/priors/track_anything/seg_tracker.py
+++ b/vipe/priors/track_anything/seg_tracker.py
@@ -5,7 +5,6 @@
 import numpy as np
 import torch
 
-
 from vipe.utils.model_cache import ModelCache
 
 from .aot_tracker import get_aot
@@ -140,7 +139,9 @@ class SegTracker:
 
     def add_mask_torch(self, interactive_mask: torch.Tensor) -> torch.Tensor:
         if self.origin_merged_mask is None:
-            self.origin_merged_mask = torch.zeros(interactive_mask.shape, dtype=torch.uint8, device=interactive_mask.device)
+            self.origin_merged_mask = torch.zeros(
+                interactive_mask.shape, dtype=torch.uint8, device=interactive_mask.device
+            )
 
         refined_merged_mask = self.origin_merged_mask.clone()
         refined_merged_mask[interactive_mask > 0] = self.curr_idx

--- a/vipe/priors/track_anything/segmentor.py
+++ b/vipe/priors/track_anything/segmentor.py
@@ -49,6 +49,12 @@ class Segmentor:
             self.have_embedded = True
 
     @torch.no_grad()
+    def set_image_tensor(self, image: torch.Tensor):
+        if not self.have_embedded:
+            self.interactive_predictor.set_image_tensor(image)
+            self.have_embedded = True
+
+    @torch.no_grad()
     def interactive_predict(self, prompts, mode, multimask=True):
         assert self.have_embedded, "image embedding for sam need be set before predict."
 
@@ -123,3 +129,52 @@ class Segmentor:
         mask = masks[np.argmax(scores)]
 
         return [mask]
+
+    @torch.no_grad()
+    def segment_with_box_tensor(
+        self,
+        origin_frame: torch.Tensor,
+        boxes: torch.Tensor,
+        reset_image: bool = False,
+    ) -> torch.Tensor:
+        if not isinstance(origin_frame, torch.Tensor):
+            raise TypeError("GPU SAM path requires origin_frame as a torch.Tensor")
+        if not isinstance(boxes, torch.Tensor):
+            raise TypeError("GPU SAM path requires boxes as a torch.Tensor")
+
+        if reset_image:
+            self.interactive_predictor.set_image_tensor(origin_frame)
+            self.have_embedded = True
+        else:
+            self.set_image_tensor(origin_frame)
+
+        boxes = boxes.to(device=self.interactive_predictor.device, dtype=torch.float32)
+        transformed_boxes = self.interactive_predictor.transform.apply_boxes_torch(
+            boxes,
+            self.interactive_predictor.original_size,
+        )
+
+        _masks, scores, logits = self.interactive_predictor.predict_torch(
+            point_coords=None,
+            point_labels=None,
+            boxes=transformed_boxes,
+            mask_input=None,
+            multimask_output=True,
+            return_logits=True,
+        )
+
+        batch_indices = torch.arange(scores.shape[0], device=scores.device)
+        best_indices = scores.argmax(dim=1)
+        best_logits = logits[batch_indices, best_indices].unsqueeze(1)
+
+        masks, scores, _logits = self.interactive_predictor.predict_torch(
+            point_coords=None,
+            point_labels=None,
+            boxes=transformed_boxes,
+            mask_input=best_logits,
+            multimask_output=True,
+            return_logits=False,
+        )
+
+        best_indices = scores.argmax(dim=1)
+        return masks[batch_indices, best_indices].to(torch.uint8)


### PR DESCRIPTION
This PR removes avoidable CPU/GPU round trips from the Track Anything pipeline by adding CUDA tensor-native paths through detection, segmentation, and tracking.

  Key changes:

  - Keep VideoFrame.rgb, detection boxes, SAM masks, AOT masks, and tracker outputs on GPU.
  - Add GPU-direct GroundingDINO preprocessing/inference instead of PIL/NumPy transforms in the hot path.
  - Add CUDA tensor input support for SAM image embedding and batched box-prompt segmentation.
  - Replace AOT’s CPU transform path with tensor-native resize/normalization and CUDA mask handling.
  - Update object-mask merging/new-object detection to operate on torch tensors.
  - Add small shared-memory padding in altcorr_index_forward_kernel.

  Behavioral note:
  - The Track Anything path now expects CUDA RGB tensors and fails fast if called with CPU/NumPy inputs.