### PR TITLE
perf(vipe): slam component preallocation probe

### DIFF
--- a/tests/test_slam_component_lifetime.py
+++ b/tests/test_slam_component_lifetime.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import torch
+from omegaconf import OmegaConf
+
+from vipe.slam import system
+from vipe.slam.networks import droid_net
+from vipe.utils.cameras import CameraType
+
+
+class _FakeRig:
+    def __init__(self) -> None:
+        self.data = torch.tensor([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]], dtype=torch.float32)
+
+    def to(self, device: torch.device) -> "_FakeRig":
+        self.data = self.data.to(device)
+        return self
+
+
+def _minimal_slam_config():
+    return OmegaConf.create(
+        {
+            "visualize": False,
+            "sparse_tracks": {"name": "dummy"},
+            "n_views": 1,
+            "height": 8,
+            "width": 8,
+            "buffer": 4,
+            "init_disp": 1.0,
+            "cross_view_idx": None,
+            "ba": {},
+            "camera_type": CameraType.PINHOLE,
+            "filter_thresh": 16.0,
+            "cross_view": False,
+            "warmup": 2,
+            "beta": 0.3,
+            "frontend_nms": 1,
+            "keyframe_thresh": 2.5,
+            "frontend_window": 4,
+            "frontend_thresh": 16.0,
+            "frontend_radius": 1,
+            "has_init_pose": False,
+            "infill_chunk_size": 2,
+            "keyframe_depth": None,
+        },
+        flags={"allow_objects": True},
+    )
+
+
+def test_shared_droid_net_reuses_frozen_eval_model(monkeypatch) -> None:
+    load_calls = 0
+
+    def fake_load_weights(self) -> None:
+        nonlocal load_calls
+        load_calls += 1
+
+    droid_net.clear_shared_droid_net_cache()
+    monkeypatch.setattr(droid_net.DroidNet, "load_weights", fake_load_weights)
+
+    try:
+        first = droid_net.get_shared_droid_net(torch.device("cpu"))
+        second = droid_net.get_shared_droid_net(torch.device("cpu"))
+    finally:
+        droid_net.clear_shared_droid_net_cache()
+
+    assert first is second
+    assert load_calls == 1
+    assert not first.training
+    assert all(not parameter.requires_grad for parameter in first.parameters())
+    assert first.image_mean.data_ptr() == second.image_mean.data_ptr()
+    assert first.image_std.data_ptr() == second.image_std.data_ptr()
+
+
+def test_slam_component_build_reuses_only_droid_net(monkeypatch) -> None:
+    droid_net.clear_shared_droid_net_cache()
+    monkeypatch.setattr(droid_net.DroidNet, "load_weights", lambda self: None)
+
+    try:
+        first = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config())
+        first.rig = _FakeRig()
+        first._build_components()
+
+        second = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config())
+        second.rig = _FakeRig()
+        second._build_components()
+    finally:
+        droid_net.clear_shared_droid_net_cache()
+
+    assert first.droid_net is second.droid_net
+    assert first.sparse_tracks is not second.sparse_tracks
+    assert first.buffer is not second.buffer
+    assert first.motion_filter is not second.motion_filter
+    assert first.frontend is not second.frontend
+    assert first.frontend.graph is not second.frontend.graph
+    assert first.backend is not second.backend
+    assert first.inner_filler is not second.inner_filler
+    assert first.buffer.poses.data_ptr() != second.buffer.poses.data_ptr()
+    assert first.buffer.cross_view_idx.data_ptr() != second.buffer.cross_view_idx.data_ptr()

--- a/tests/test_slam_component_lifetime.py
+++ b/tests/test_slam_component_lifetime.py
@@ -6,6 +6,7 @@ from omegaconf import OmegaConf
 from vipe.slam import system
 from vipe.slam.networks import droid_net
 from vipe.utils.cameras import CameraType
+from vipe.utils.model_cache import ModelCache
 
 
 class _FakeRig:
@@ -47,21 +48,21 @@ def _minimal_slam_config():
     )
 
 
-def test_shared_droid_net_reuses_frozen_eval_model(monkeypatch) -> None:
+def test_model_cache_reuses_frozen_eval_droid_net(monkeypatch) -> None:
     load_calls = 0
 
     def fake_load_weights(self) -> None:
         nonlocal load_calls
         load_calls += 1
 
-    droid_net.clear_shared_droid_net_cache()
+    model_cache = ModelCache()
     monkeypatch.setattr(droid_net.DroidNet, "load_weights", fake_load_weights)
 
     try:
-        first = droid_net.get_shared_droid_net(torch.device("cpu"))
-        second = droid_net.get_shared_droid_net(torch.device("cpu"))
+        first = droid_net.get_droid_net(torch.device("cpu"), model_cache)
+        second = droid_net.get_droid_net(torch.device("cpu"), model_cache)
     finally:
-        droid_net.clear_shared_droid_net_cache()
+        model_cache.clear()
 
     assert first is second
     assert load_calls == 1
@@ -71,20 +72,36 @@ def test_shared_droid_net_reuses_frozen_eval_model(monkeypatch) -> None:
     assert first.image_std.data_ptr() == second.image_std.data_ptr()
 
 
+def test_droid_net_without_model_cache_is_not_shared(monkeypatch) -> None:
+    load_calls = 0
+
+    def fake_load_weights(self) -> None:
+        nonlocal load_calls
+        load_calls += 1
+
+    monkeypatch.setattr(droid_net.DroidNet, "load_weights", fake_load_weights)
+
+    first = droid_net.get_droid_net(torch.device("cpu"))
+    second = droid_net.get_droid_net(torch.device("cpu"))
+
+    assert first is not second
+    assert load_calls == 2
+
+
 def test_slam_component_build_reuses_only_droid_net(monkeypatch) -> None:
-    droid_net.clear_shared_droid_net_cache()
+    model_cache = ModelCache()
     monkeypatch.setattr(droid_net.DroidNet, "load_weights", lambda self: None)
 
     try:
-        first = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config())
+        first = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config(), model_cache=model_cache)
         first.rig = _FakeRig()
         first._build_components()
 
-        second = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config())
+        second = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config(), model_cache=model_cache)
         second.rig = _FakeRig()
         second._build_components()
     finally:
-        droid_net.clear_shared_droid_net_cache()
+        model_cache.clear()
 
     assert first.droid_net is second.droid_net
     assert first.sparse_tracks is not second.sparse_tracks
@@ -96,3 +113,17 @@ def test_slam_component_build_reuses_only_droid_net(monkeypatch) -> None:
     assert first.inner_filler is not second.inner_filler
     assert first.buffer.poses.data_ptr() != second.buffer.poses.data_ptr()
     assert first.buffer.cross_view_idx.data_ptr() != second.buffer.cross_view_idx.data_ptr()
+
+
+def test_slam_component_build_without_model_cache_does_not_share_droid_net(monkeypatch) -> None:
+    monkeypatch.setattr(droid_net.DroidNet, "load_weights", lambda self: None)
+
+    first = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config())
+    first.rig = _FakeRig()
+    first._build_components()
+
+    second = system.SLAMSystem(torch.device("cpu"), _minimal_slam_config())
+    second.rig = _FakeRig()
+    second._build_components()
+
+    assert first.droid_net is not second.droid_net

--- a/vipe/slam/networks/droid_net.py
+++ b/vipe/slam/networks/droid_net.py
@@ -18,8 +18,6 @@
 # Licensed under the MIT License. See THIRD_PARTY_LICENSES.md for details.
 # -------------------------------------------------------------------------------------------------
 
-import logging
-import threading
 from collections import OrderedDict
 from pathlib import Path
 
@@ -29,10 +27,7 @@ import torch.nn.functional as F
 
 from vipe.ext import droid_net_ext
 from vipe.ext.scatter import scatter_mean
-
-logger = logging.getLogger(__name__)
-_DROID_NET_CACHE: dict[str, "DroidNet"] = {}
-_DROID_NET_CACHE_LOCK = threading.Lock()
+from vipe.utils.model_cache import ModelCache
 
 
 class CorrSampler(torch.autograd.Function):
@@ -594,24 +589,17 @@ def _normalize_droid_net_device(device: torch.device) -> torch.device:
     return device
 
 
-def get_shared_droid_net(device: torch.device) -> DroidNet:
-    """Return the immutable process-local DroidNet for a device."""
+def _build_cached_droid_net(device: torch.device) -> DroidNet:
     normalized_device = _normalize_droid_net_device(device)
-    cache_key = str(normalized_device)
-    with _DROID_NET_CACHE_LOCK:
-        net = _DROID_NET_CACHE.get(cache_key)
-        if net is None:
-            logger.info("Loading shared DroidNet on %s", cache_key)
-            net = DroidNet().to(normalized_device)
-            net.eval()
-            net.requires_grad_(False)
-            _DROID_NET_CACHE[cache_key] = net
-        else:
-            logger.info("Reusing shared DroidNet on %s", cache_key)
+    net = DroidNet().to(normalized_device)
+    net.eval()
+    net.requires_grad_(False)
     return net
 
 
-def clear_shared_droid_net_cache() -> None:
-    """Clear the process-local DroidNet cache for tests."""
-    with _DROID_NET_CACHE_LOCK:
-        _DROID_NET_CACHE.clear()
+def get_droid_net(device: torch.device, model_cache: ModelCache | None = None) -> DroidNet:
+    """Build DroidNet, optionally reusing the caller-owned model cache."""
+    normalized_device = _normalize_droid_net_device(device)
+    if model_cache is None:
+        return DroidNet().to(normalized_device)
+    return model_cache.get(f"slam/droid_net/{normalized_device}", lambda: _build_cached_droid_net(normalized_device))

--- a/vipe/slam/networks/droid_net.py
+++ b/vipe/slam/networks/droid_net.py
@@ -582,24 +582,19 @@ class DroidNet(nn.Module):
         self.eval()
 
 
-def _normalize_droid_net_device(device: torch.device) -> torch.device:
-    device = torch.device(device)
-    if device.type == "cuda" and device.index is None and torch.cuda.is_available():
-        return torch.device("cuda", torch.cuda.current_device())
-    return device
-
-
-def _build_cached_droid_net(device: torch.device) -> DroidNet:
-    normalized_device = _normalize_droid_net_device(device)
-    net = DroidNet().to(normalized_device)
-    net.eval()
-    net.requires_grad_(False)
-    return net
-
-
 def get_droid_net(device: torch.device, model_cache: ModelCache | None = None) -> DroidNet:
     """Build DroidNet, optionally reusing the caller-owned model cache."""
-    normalized_device = _normalize_droid_net_device(device)
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None and torch.cuda.is_available():
+        device = torch.device("cuda", torch.cuda.current_device())
+
     if model_cache is None:
-        return DroidNet().to(normalized_device)
-    return model_cache.get(f"slam/droid_net/{normalized_device}", lambda: _build_cached_droid_net(normalized_device))
+        return DroidNet().to(device)
+
+    def build_cached_droid_net() -> DroidNet:
+        net = DroidNet().to(device)
+        net.eval()
+        net.requires_grad_(False)
+        return net
+
+    return model_cache.get(f"slam/droid_net/{device}", build_cached_droid_net)

--- a/vipe/slam/networks/droid_net.py
+++ b/vipe/slam/networks/droid_net.py
@@ -18,6 +18,8 @@
 # Licensed under the MIT License. See THIRD_PARTY_LICENSES.md for details.
 # -------------------------------------------------------------------------------------------------
 
+import logging
+import threading
 from collections import OrderedDict
 from pathlib import Path
 
@@ -27,6 +29,10 @@ import torch.nn.functional as F
 
 from vipe.ext import droid_net_ext
 from vipe.ext.scatter import scatter_mean
+
+logger = logging.getLogger(__name__)
+_DROID_NET_CACHE: dict[str, "DroidNet"] = {}
+_DROID_NET_CACHE_LOCK = threading.Lock()
 
 
 class CorrSampler(torch.autograd.Function):
@@ -525,24 +531,30 @@ class DroidNet(nn.Module):
         self.fnet = BasicEncoder(output_dim=128, norm_fn="instance")
         self.cnet = BasicEncoder(output_dim=256, norm_fn="none")
         self.update = UpdateModule()
+        self.register_buffer(
+            "image_mean",
+            torch.tensor([0.485, 0.456, 0.406], dtype=torch.float32).view(1, 1, 3, 1, 1),
+            persistent=False,
+        )
+        self.register_buffer(
+            "image_std",
+            torch.tensor([0.229, 0.224, 0.225], dtype=torch.float32).view(1, 1, 3, 1, 1),
+            persistent=False,
+        )
         self.load_weights()
 
     @torch.amp.autocast("cuda", enabled=True)
     def encode_features(self, images: torch.Tensor):
         """image (torch.Tensor): BCHW image RGB 0-1"""
-        mean = torch.as_tensor([0.485, 0.456, 0.406], device=images.device)
-        std = torch.as_tensor([0.229, 0.224, 0.225], device=images.device)
         # (1, B, C, H, W) - (x, x, 3, 1, 1)
-        images = (images[None] - mean[:, None, None]) / std[:, None, None]
+        images = (images[None] - self.image_mean) / self.image_std
         return self.fnet(images).squeeze(0)
 
     @torch.amp.autocast("cuda", enabled=True)
     def encode_context(self, images: torch.Tensor):
         """image (torch.Tensor): BCHW image RGB 0-1"""
-        mean = torch.as_tensor([0.485, 0.456, 0.406], device=images.device)
-        std = torch.as_tensor([0.229, 0.224, 0.225], device=images.device)
         # (1, B, C, H, W) - (x, x, 3, 1, 1)
-        images = (images[None] - mean[:, None, None]) / std[:, None, None]
+        images = (images[None] - self.image_mean) / self.image_std
         net, inp = self.cnet(images).split([128, 128], dim=2)
         return net.tanh().squeeze(0), inp.relu().squeeze(0)
 
@@ -570,3 +582,33 @@ class DroidNet(nn.Module):
 
         self.load_state_dict(state_dict)
         self.eval()
+
+
+def _normalize_droid_net_device(device: torch.device) -> torch.device:
+    device = torch.device(device)
+    if device.type == "cuda" and device.index is None and torch.cuda.is_available():
+        return torch.device("cuda", torch.cuda.current_device())
+    return device
+
+
+def get_shared_droid_net(device: torch.device) -> DroidNet:
+    """Return the immutable process-local DroidNet for a device."""
+    normalized_device = _normalize_droid_net_device(device)
+    cache_key = str(normalized_device)
+    with _DROID_NET_CACHE_LOCK:
+        net = _DROID_NET_CACHE.get(cache_key)
+        if net is None:
+            logger.info("Loading shared DroidNet on %s", cache_key)
+            net = DroidNet().to(normalized_device)
+            net.eval()
+            net.requires_grad_(False)
+            _DROID_NET_CACHE[cache_key] = net
+        else:
+            logger.info("Reusing shared DroidNet on %s", cache_key)
+    return net
+
+
+def clear_shared_droid_net_cache() -> None:
+    """Clear the process-local DroidNet cache for tests."""
+    with _DROID_NET_CACHE_LOCK:
+        _DROID_NET_CACHE.clear()

--- a/vipe/slam/networks/droid_net.py
+++ b/vipe/slam/networks/droid_net.py
@@ -526,6 +526,9 @@ class UpdateModule(nn.Module):
 
 
 class DroidNet(nn.Module):
+    image_mean: torch.Tensor
+    image_std: torch.Tensor
+
     def __init__(self):
         super(DroidNet, self).__init__()
         self.fnet = BasicEncoder(output_dim=128, norm_fn="instance")

--- a/vipe/slam/system.py
+++ b/vipe/slam/system.py
@@ -38,7 +38,7 @@ from .components.inner_filler import FilledReturn, InnerFiller
 from .components.motion_filter import MotionFilter
 from .components.sparse_tracks import build_sparse_tracks
 from .interface import SLAMOutput
-from .networks.droid_net import get_shared_droid_net
+from .networks.droid_net import get_droid_net
 
 
 class StandardResizeStreamProcessor(StreamProcessor):
@@ -90,7 +90,7 @@ class SLAMSystem:
         OmegaConf.set_struct(self.config, False)
 
     def _build_components(self):
-        self.droid_net = get_shared_droid_net(self.device)
+        self.droid_net = get_droid_net(self.device, self.model_cache)
         self.sparse_tracks = build_sparse_tracks(self.config.sparse_tracks, self.config.n_views)
         self.buffer = GraphBuffer(
             height=self.config.height,

--- a/vipe/slam/system.py
+++ b/vipe/slam/system.py
@@ -38,7 +38,7 @@ from .components.inner_filler import FilledReturn, InnerFiller
 from .components.motion_filter import MotionFilter
 from .components.sparse_tracks import build_sparse_tracks
 from .interface import SLAMOutput
-from .networks.droid_net import DroidNet
+from .networks.droid_net import get_shared_droid_net
 
 
 class StandardResizeStreamProcessor(StreamProcessor):
@@ -90,7 +90,7 @@ class SLAMSystem:
         OmegaConf.set_struct(self.config, False)
 
     def _build_components(self):
-        self.droid_net = DroidNet().to(self.device)
+        self.droid_net = get_shared_droid_net(self.device)
         self.sparse_tracks = build_sparse_tracks(self.config.sparse_tracks, self.config.n_views)
         self.buffer = GraphBuffer(
             height=self.config.height,


### PR DESCRIPTION
Add shared DroidNet cache helpers so SLAM component setup can reuse an already-loaded network for the same normalized device instead of constructing a fresh model for every system.

Register the image mean/std normalization constants as buffers on DroidNet, which keeps those constants device-resident and avoids recreating/transferring them during feature and context encoding.

The cache remains explicit and bounded by device keying plus a clear helper, so this reduces repeated setup overhead without changing default model behavior.