### PR TITLE
  Add async init prefetch with serialized fallback

### DIFF
--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -8,6 +8,7 @@ init:
   camera_type: "pinhole"
   intrinsics: "geocalib"
   async_prefetch: true
+  prefetch_queue_size: 16
   instance:
     kf_gap_sec: 2.0
     phrases: 

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -7,6 +7,7 @@ instance: vipe.pipeline.default.DefaultAnnotationPipeline
 init:
   camera_type: "pinhole"
   intrinsics: "geocalib"
+  async_prefetch: true
   instance:
     kf_gap_sec: 2.0
     phrases: 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -108,6 +108,7 @@ Initialization options for the default pinhole and wide-angle pipelines.
 | `intrinsics` | `geocalib` \| `gt` | required | choices `geocalib` \| `gt` | Source of camera intrinsics. geocalib estimates intrinsics; gt expects each frame to provide them. |
 | `instance` | InstanceInitConfig \| null | required | - | Instance-segmentation initialization. Set to null to skip instance masks. |
 | `async_prefetch` | bool | `true` | - | Prefetch initialized frames asynchronously before SLAM. Set false to use serialized caching. |
+| `prefetch_queue_size` | int | `16` | >= 1 | Maximum number of initialized frames the async producer may keep ready ahead of SLAM. |
 
 ### PanoramaInitConfig
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -107,6 +107,7 @@ Initialization options for the default pinhole and wide-angle pipelines.
 | `camera_type` | `pinhole` \| `panorama` \| `simple_divisional` \| `mei` | required | choices `pinhole` \| `panorama` \| `simple_divisional` \| `mei` | Camera model used by SLAM and projection code. Use mei for wide-angle/fisheye input. |
 | `intrinsics` | `geocalib` \| `gt` | required | choices `geocalib` \| `gt` | Source of camera intrinsics. geocalib estimates intrinsics; gt expects each frame to provide them. |
 | `instance` | InstanceInitConfig \| null | required | - | Instance-segmentation initialization. Set to null to skip instance masks. |
+| `async_prefetch` | bool | `true` | - | Prefetch initialized frames asynchronously before SLAM. Set false to use serialized caching. |
 
 ### PanoramaInitConfig
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,7 +171,9 @@ def test_default_init_async_prefetch_can_fall_back_to_serialized_cache(tmp_path:
 
     assert isinstance(config.pipeline, DefaultPipelineConfig)
     assert config.pipeline.init.async_prefetch is False
+    assert config.pipeline.init.prefetch_queue_size == 16
     assert config.pipeline.to_dictconfig().init.async_prefetch is False
+    assert config.pipeline.to_dictconfig().init.prefetch_queue_size == 16
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -163,6 +163,17 @@ def test_default_config_ships_auto_fused_ba(tmp_path: Path) -> None:
     assert config.pipeline.slam.ba.fused is True
 
 
+def test_default_init_async_prefetch_can_fall_back_to_serialized_cache(tmp_path: Path) -> None:
+    config = parse_typed_config(
+        "default",
+        [*_base_overrides(tmp_path), "pipeline.init.async_prefetch=false"],
+    )
+
+    assert isinstance(config.pipeline, DefaultPipelineConfig)
+    assert config.pipeline.init.async_prefetch is False
+    assert config.pipeline.to_dictconfig().init.async_prefetch is False
+
+
 @pytest.mark.parametrize(
     "override",
     [

--- a/vipe/config/pipeline.py
+++ b/vipe/config/pipeline.py
@@ -45,6 +45,11 @@ class DefaultInitConfig(BaseConfigSchema):
         default=True,
         description="Prefetch initialized frames asynchronously before SLAM. Set false to use serialized caching.",
     )
+    prefetch_queue_size: int = Field(
+        default=16,
+        ge=1,
+        description="Maximum number of initialized frames the async producer may keep ready ahead of SLAM.",
+    )
 
 
 class PanoramaInitConfig(BaseConfigSchema):

--- a/vipe/config/pipeline.py
+++ b/vipe/config/pipeline.py
@@ -41,6 +41,10 @@ class DefaultInitConfig(BaseConfigSchema):
     instance: InstanceInitConfig | None = Field(
         description="Instance-segmentation initialization. Set to null to skip instance masks."
     )
+    async_prefetch: bool = Field(
+        default=True,
+        description="Prefetch initialized frames asynchronously before SLAM. Set false to use serialized caching.",
+    )
 
 
 class PanoramaInitConfig(BaseConfigSchema):

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -117,12 +117,13 @@ class DefaultAnnotationPipeline(Pipeline):
             return annotate_output
 
         async_prefetch = bool(getattr(self.init_cfg, "async_prefetch", True))
+        prefetch_queue_size = int(getattr(self.init_cfg, "prefetch_queue_size", 16))
         slam_streams: list[VideoStream] = [
             self._add_init_processors(video_stream).cache(
                 "process",
                 online=True,
                 async_prefetch=async_prefetch,
-                prefetch_depth=2,
+                prefetch_queue_size=prefetch_queue_size,
             )
             for video_stream in video_streams
         ]

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -45,6 +45,18 @@ from .processors import (
 logger = logging.getLogger(__name__)
 
 
+def _async_init_prefetch_enabled() -> bool:
+    return os.environ.get("VIPE_ASYNC_INIT_PREFETCH") == "1"
+
+
+def _async_init_prefetch_depth() -> int:
+    value = os.environ.get("VIPE_ASYNC_INIT_PREFETCH_DEPTH", "2")
+    try:
+        return max(1, int(value))
+    except ValueError as exc:
+        raise ValueError(f"VIPE_ASYNC_INIT_PREFETCH_DEPTH must be an integer, got {value!r}") from exc
+
+
 class DefaultAnnotationPipeline(Pipeline):
     def __init__(self, init: DictConfig, slam: DictConfig, post: DictConfig, output: DictConfig) -> None:
         super().__init__()
@@ -116,8 +128,16 @@ class DefaultAnnotationPipeline(Pipeline):
             logger.info(f"{video_data.name()} has been proccessed already, skip it!!")
             return annotate_output
 
+        async_prefetch = _async_init_prefetch_enabled()
+        prefetch_depth = _async_init_prefetch_depth() if async_prefetch else 2
         slam_streams: list[VideoStream] = [
-            self._add_init_processors(video_stream).cache("process", online=True) for video_stream in video_streams
+            self._add_init_processors(video_stream).cache(
+                "process",
+                online=True,
+                async_prefetch=async_prefetch,
+                prefetch_depth=prefetch_depth,
+            )
+            for video_stream in video_streams
         ]
 
         slam_pipeline = SLAMSystem(device=torch.device("cuda"), config=self.slam_cfg, model_cache=self.model_cache)

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -15,7 +15,6 @@
 
 
 import logging
-import os
 import pickle
 from pathlib import Path
 
@@ -44,18 +43,6 @@ from .processors import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _async_init_prefetch_enabled() -> bool:
-    return os.environ.get("VIPE_ASYNC_INIT_PREFETCH") == "1"
-
-
-def _async_init_prefetch_depth() -> int:
-    value = os.environ.get("VIPE_ASYNC_INIT_PREFETCH_DEPTH", "2")
-    try:
-        return max(1, int(value))
-    except ValueError as exc:
-        raise ValueError(f"VIPE_ASYNC_INIT_PREFETCH_DEPTH must be an integer, got {value!r}") from exc
 
 
 class DefaultAnnotationPipeline(Pipeline):
@@ -129,14 +116,13 @@ class DefaultAnnotationPipeline(Pipeline):
             logger.info(f"{video_data.name()} has been proccessed already, skip it!!")
             return annotate_output
 
-        async_prefetch = _async_init_prefetch_enabled()
-        prefetch_depth = _async_init_prefetch_depth() if async_prefetch else 2
+        async_prefetch = bool(getattr(self.init_cfg, "async_prefetch", True))
         slam_streams: list[VideoStream] = [
             self._add_init_processors(video_stream).cache(
                 "process",
                 online=True,
                 async_prefetch=async_prefetch,
-                prefetch_depth=prefetch_depth,
+                prefetch_depth=2,
             )
             for video_stream in video_streams
         ]

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -15,6 +15,7 @@
 
 
 import logging
+import os
 import pickle
 from pathlib import Path
 

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -116,8 +116,8 @@ class DefaultAnnotationPipeline(Pipeline):
             logger.info(f"{video_data.name()} has been proccessed already, skip it!!")
             return annotate_output
 
-        async_prefetch = bool(getattr(self.init_cfg, "async_prefetch", True))
-        prefetch_queue_size = int(getattr(self.init_cfg, "prefetch_queue_size", 16))
+        async_prefetch = self.init_cfg.async_prefetch
+        prefetch_queue_size = self.init_cfg.prefetch_queue_size
         slam_streams: list[VideoStream] = [
             self._add_init_processors(video_stream).cache(
                 "process",

--- a/vipe/streams/base.py
+++ b/vipe/streams/base.py
@@ -429,11 +429,13 @@ class AsyncCachedVideoStream(VideoStream):
     This preserves the CachedVideoStream external behavior while allowing a
     pull-driven consumer to overlap downstream work with upstream processors.
     Frames are still yielded in strict order and cached on CPU for later reuse.
+    The prefetch queue size is the maximum number of frames the producer may
+    keep ready ahead of the next requested consumer frame.
     """
 
     DISPLAY_THRESH = CachedVideoStream.DISPLAY_THRESH
 
-    def __init__(self, video_stream: VideoStream, desc: str = "Caching", prefetch_depth: int = 2) -> None:
+    def __init__(self, video_stream: VideoStream, desc: str = "Caching", prefetch_queue_size: int = 16) -> None:
         self._frame_size = video_stream.frame_size()
         self._fps = video_stream.fps()
         self._name = video_stream.name()
@@ -442,7 +444,7 @@ class AsyncCachedVideoStream(VideoStream):
         self.iterator: Iterator[VideoFrame] | None = iter(video_stream)
         self.data: list[VideoFrame] = []
         self.desc = desc
-        self.prefetch_depth = max(1, int(prefetch_depth))
+        self.prefetch_queue_size = max(1, int(prefetch_queue_size))
         self._requested_until = -1
         self._done = False
         self._error: BaseException | None = None
@@ -454,7 +456,7 @@ class AsyncCachedVideoStream(VideoStream):
         try:
             while True:
                 with self._condition:
-                    while not self._done and len(self.data) - (self._requested_until + 1) >= self.prefetch_depth:
+                    while not self._done and len(self.data) - (self._requested_until + 1) >= self.prefetch_queue_size:
                         self._condition.wait()
                     if self._done:
                         return
@@ -595,11 +597,11 @@ class ProcessedVideoStream(VideoStream):
         desc: str = "Caching",
         online: bool = False,
         async_prefetch: bool = False,
-        prefetch_depth: int = 2,
+        prefetch_queue_size: int = 16,
     ) -> CachedVideoStream | AsyncCachedVideoStream:
         vs: CachedVideoStream | AsyncCachedVideoStream
         if async_prefetch:
-            vs = AsyncCachedVideoStream(self, desc, prefetch_depth=prefetch_depth)
+            vs = AsyncCachedVideoStream(self, desc, prefetch_queue_size=prefetch_queue_size)
         else:
             vs = CachedVideoStream(self, desc)
 

--- a/vipe/streams/base.py
+++ b/vipe/streams/base.py
@@ -16,6 +16,7 @@
 import copy
 import importlib
 import logging
+import threading
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Iterable, Iterator, Protocol, cast
@@ -421,6 +422,106 @@ class CachedVideoStream(VideoStream):
         return self._attributes
 
 
+class AsyncCachedVideoStream(VideoStream):
+    """
+    Cache a video stream from a producer thread.
+
+    This preserves the CachedVideoStream external behavior while allowing a
+    pull-driven consumer to overlap downstream work with upstream processors.
+    Frames are still yielded in strict order and cached on CPU for later reuse.
+    """
+
+    DISPLAY_THRESH = CachedVideoStream.DISPLAY_THRESH
+
+    def __init__(self, video_stream: VideoStream, desc: str = "Caching", prefetch_depth: int = 2) -> None:
+        self._frame_size = video_stream.frame_size()
+        self._fps = video_stream.fps()
+        self._name = video_stream.name()
+        self._attributes = video_stream.attributes()
+        self._len = len(video_stream)
+        self.iterator: Iterator[VideoFrame] | None = iter(video_stream)
+        self.data: list[VideoFrame] = []
+        self.desc = desc
+        self.prefetch_depth = max(1, int(prefetch_depth))
+        self._requested_until = -1
+        self._done = False
+        self._error: BaseException | None = None
+        self._condition = threading.Condition()
+        self._producer = threading.Thread(target=self._produce, name=f"{type(self).__name__}:{self._name}", daemon=True)
+        self._producer.start()
+
+    def _produce(self) -> None:
+        try:
+            while True:
+                with self._condition:
+                    while not self._done and len(self.data) - (self._requested_until + 1) >= self.prefetch_depth:
+                        self._condition.wait()
+                    if self._done:
+                        return
+
+                assert self.iterator is not None
+                try:
+                    frame = next(self.iterator).cpu()
+                except StopIteration:
+                    with self._condition:
+                        if len(self.data) != self._len:
+                            logger.warning(
+                                "Iterator is exhausted -- expecting total frames = %d, stopped at %d",
+                                self._len,
+                                len(self.data),
+                            )
+                            self._len = len(self.data)
+                        self.iterator = None
+                        self._done = True
+                        self._condition.notify_all()
+                    torch.cuda.empty_cache()
+                    return
+
+                with self._condition:
+                    self.data.append(frame)
+                    self._condition.notify_all()
+        except BaseException as exc:
+            with self._condition:
+                self._error = exc
+                self._done = True
+                self._condition.notify_all()
+
+    def fps(self) -> float:
+        return self._fps
+
+    def frame_size(self) -> tuple[int, int]:
+        return self._frame_size
+
+    def name(self) -> str:
+        return self._name
+
+    def __len__(self) -> int:
+        return self._len
+
+    def __getitem__(self, index) -> VideoFrame:
+        assert index < len(self)
+        with self._condition:
+            self._requested_until = max(self._requested_until, index)
+            self._condition.notify_all()
+            while len(self.data) <= index and not self._done and self._error is None:
+                self._condition.wait()
+            if self._error is not None:
+                raise RuntimeError(f"Async stream producer failed while caching {self._name}") from self._error
+            if index >= len(self.data):
+                raise IndexError(f"Frame index {index} is unavailable in {self._name}; cached {len(self.data)} frames")
+            frame = self.data[index]
+        return frame.cuda()
+
+    def __iter__(self):
+        for idx in range(len(self)):
+            if idx >= len(self):
+                break
+            yield self[idx]
+
+    def attributes(self) -> set[FrameAttribute]:
+        return self._attributes
+
+
 class StreamProcessor(Protocol):
     """
     Interface of a stream processor that processes each video frame.
@@ -489,8 +590,17 @@ class ProcessedVideoStream(VideoStream):
     def name(self) -> str:
         return self.stream.name()
 
-    def cache(self, desc: str = "Caching", online: bool = False) -> CachedVideoStream:
-        vs = CachedVideoStream(self, desc)
+    def cache(
+        self,
+        desc: str = "Caching",
+        online: bool = False,
+        async_prefetch: bool = False,
+        prefetch_depth: int = 2,
+    ) -> CachedVideoStream | AsyncCachedVideoStream:
+        if async_prefetch:
+            vs = AsyncCachedVideoStream(self, desc, prefetch_depth=prefetch_depth)
+        else:
+            vs = CachedVideoStream(self, desc)
 
         # If not online, we trigger __getitem__ of the last element to force storing all frames.
         if not online:

--- a/vipe/streams/base.py
+++ b/vipe/streams/base.py
@@ -597,6 +597,7 @@ class ProcessedVideoStream(VideoStream):
         async_prefetch: bool = False,
         prefetch_depth: int = 2,
     ) -> CachedVideoStream | AsyncCachedVideoStream:
+        vs: CachedVideoStream | AsyncCachedVideoStream
         if async_prefetch:
             vs = AsyncCachedVideoStream(self, desc, prefetch_depth=prefetch_depth)
         else:


### PR DESCRIPTION
Summary
  - Adds async init prefetch as the default cache path before SLAM.
  - Adds `pipeline.init.async_prefetch=false` to fall back to the serialized cache behavior.
  - Fixes lint/type-check coverage for the cache wrapper type.
