### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ViPE estimates camera intrinsics, camera motion, and dense near-metric depth map
 
 ## News
 
+- **2026/06**: Released ViPE 1.2.0 with CUDA fused kernels, model and pipeline caching, prefetching, and other optimizations, achieving a 2.7x speed-up with no loss of accuracy.
 - **2026/05**: Merged Panorama estimation pipeline & bump release version to 1.0.0.
 - **2026/01**: Integration with [Depth-Anything 3](https://github.com/ByteDance-Seed/Depth-Anything-3) for depth estimation (use `dav3` pipeline).
 - **2025/10**: Add support to run on wide-angle videos.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ViPE estimates camera intrinsics, camera motion, and dense near-metric depth map
 
 ## News
 
-- **2026/06**: Released ViPE 1.2.0 with CUDA fused kernels, model and pipeline caching, prefetching, and other optimizations, achieving a 2.7x speed-up with no loss of accuracy.
+- **2026/06**: 🚀🚀🚀 Released ViPE 1.2.0: **2.7x speed-up with no loss of accuracy**, enabled by CUDA fused kernels, model and pipeline caching, prefetching, and other optimizations.
 - **2026/05**: Merged Panorama estimation pipeline & bump release version to 1.0.0.
 - **2026/01**: Integration with [Depth-Anything 3](https://github.com/ByteDance-Seed/Depth-Anything-3) for depth estimation (use `dav3` pipeline).
 - **2025/10**: Add support to run on wide-angle videos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ ignore_missing_imports = true
 
 [project]
 name = "nvidia-vipe"
-version = "1.1.0"
+version = "1.2.0"
 description = "NVIDIA Video Pose Engine"
 authors = [
     {name = "The ViPE Authors", email = "jiahuih@nvidia.com"},

--- a/uv.lock
+++ b/uv.lock
@@ -2340,7 +2340,7 @@ wheels = [
 
 [[package]]
 name = "nvidia-vipe"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump nvidia-vipe to 1.2.0 in pyproject.toml and uv.lock
- Add README news for CUDA fused kernels, caching, prefetching, and the 2.7x speed-up without accuracy loss

## Validation
- uv lock
- git diff --check