### PR TITLE
feat: merge community improvements (pose-only, cached depth, dynamic masks, TSDF, GEN3C export)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,8 @@ playground.py
 TODO.md
 vipe_results/
 vipe_results*/
+bench_results/
+assets/examples/test.mp4
 ci_outputs/
 /try_*.py
 /external/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# ViPE: Video Pose Engine for Geometric 3D Perception
+# ViPE: Video Pose Engine for Geometric 3D Perception (with Voxel-Aligned TSDF Integration)
+
+> **Fork Update:** This repository is a customized fork of NVIDIA's ViPE. It introduces **Voxel-Aligned TSDF Integration** utilizing Open3D to bypass the "Pixel-Aligned Trap" of standard dense depth unprojection. This ensures that overlapping fragmentation and view-bias are mathematically averaged out into a sparse, uniform point cloud (`.ply`). It can be enabled by setting `save_tsdf_ply: true` in the pipeline config (`configs/pipeline/default.yaml`).
+> 
+> *Changes made by nbardy.*
 
 <p align="center">
   <img src="assets/teaser.gif" alt="teaser"/>

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 > **Fork Update:** This repository is a customized fork of NVIDIA's ViPE. It introduces **Voxel-Aligned TSDF Integration** utilizing Open3D to bypass the "Pixel-Aligned Trap" of standard dense depth unprojection. This ensures that overlapping fragmentation and view-bias are mathematically averaged out into a sparse, uniform point cloud (`.ply`). 
 >
-> In addition to the base TSDF fusion, this fork includes:
-> - **Dynamic Object Masking:** Leverages ViPE's dynamic masks to ignore moving objects, preventing "ghost" floaters in the static environment.
-> - **Depth Edge Pruning:** Calculates spatial gradients using Sobel operators and drops high-gradient pixels (to eliminate DA3's "comet tail" smearing over hard boundaries).
-> - **Statistical Outlier Removal (SOR):** Applies a final cleanup pass over the extracted point cloud to strip out any rogue voxels that survived the integration.
+> In addition to the base TSDF fusion, this fork includes several advanced filtering steps, all of which are configurable in `configs/pipeline/default.yaml`:
 > 
-> It can be enabled by setting `save_tsdf_ply: true` in the pipeline config (`configs/pipeline/default.yaml`).
+> - **Dynamic Object Masking (`tsdf_apply_dynamic_mask: true`):** Leverages ViPE's dynamic masks to ignore moving objects (people, cars), preventing "ghost" floaters in the static environment.
+> - **Depth Edge Pruning (`tsdf_apply_edge_pruning: true`):** Calculates spatial gradients using Sobel operators and drops high-gradient pixels. This eliminates DA3's "comet tail" smearing over hard boundaries (the "flying pixel" problem, where blended boundary depths create fake geometry bridging foreground objects to the background). You can tune this via `tsdf_edge_pruning_threshold` (default `0.5`).
+> - **Statistical Outlier Removal (SOR) (`tsdf_apply_sor: true`):** Applies a final cleanup pass over the extracted point cloud to strip out any rogue voxels that survived the integration. You can tune this via `tsdf_sor_nb_neighbors` (default `50`) and `tsdf_sor_std_ratio` (default `2.0`).
+> 
+> **How to Use:**
+> Enable this feature by setting `save_tsdf_ply: true` in your active pipeline config (e.g., `configs/pipeline/default.yaml`).
 > 
 > *Changes made by nbardy.*
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > In addition to the base TSDF fusion, this fork includes several advanced filtering steps, all of which are configurable in `configs/pipeline/default.yaml`:
 > 
 > - **Dynamic Object Masking (`tsdf_apply_dynamic_mask: true`):** Leverages ViPE's dynamic masks to ignore moving objects (people, cars), preventing "ghost" floaters in the static environment.
-> - **Depth Edge Pruning (`tsdf_apply_edge_pruning: true`):** Calculates spatial gradients using Sobel operators and drops high-gradient pixels. This eliminates DA3's "comet tail" smearing over hard boundaries (the "flying pixel" problem, where blended boundary depths create fake geometry bridging foreground objects to the background). You can tune this via `tsdf_edge_pruning_threshold` (default `0.5`).
+> - **Relative Depth Pruning (`tsdf_apply_edge_pruning: true`):** DA3 is monocular and smears depth across occlusion boundaries. Naive absolute pruning deletes thin structures (like wires). We calculate the relative spatial gradient to drop pixels where depth jumps significantly, severing "comet tails" without erasing structural details. You can ablate this via `tsdf_pruning_threshold` (e.g., `0.05` for Aggressive, `0.10` for Balanced, `0.20` for Relaxed).
 > - **Statistical Outlier Removal (SOR) (`tsdf_apply_sor: true`):** Applies a final cleanup pass over the extracted point cloud to strip out any rogue voxels that survived the integration. You can tune this via `tsdf_sor_nb_neighbors` (default `50`) and `tsdf_sor_std_ratio` (default `2.0`).
 > 
 > **How to Use:**

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > In addition to the base TSDF fusion, this fork includes several advanced filtering steps, all of which are configurable in `configs/pipeline/default.yaml`:
 > 
 > - **Dynamic Object Masking (`tsdf_apply_dynamic_mask: true`):** Leverages ViPE's dynamic masks to ignore moving objects (people, cars), preventing "ghost" floaters in the static environment.
+> - **Dynamic Depth Truncation (`tsdf_depth_trunc: "auto"`):** Distant monocular depth predictions carry exponentially more noise. Rather than using a hardcoded cutoff (like 10 meters), setting this to `"auto"` dynamically calculates the Interquartile Range (IQR) fence (`Q3 + 1.5 * IQR`) of the depth map per frame. This mathematically bounds the scene, safely preserving continuous deep horizons while amputating noisy sky-box errors.
 > - **Relative Depth Pruning (`tsdf_apply_edge_pruning: true`):** DA3 is monocular and smears depth across occlusion boundaries. Naive absolute pruning deletes thin structures (like wires). We calculate the relative spatial gradient to drop pixels where depth jumps significantly, severing "comet tails" without erasing structural details. You can ablate this via `tsdf_pruning_threshold` (e.g., `0.05` for Aggressive, `0.10` for Balanced, `0.20` for Relaxed).
 > - **Statistical Outlier Removal (SOR) (`tsdf_apply_sor: true`):** Applies a final cleanup pass over the extracted point cloud to strip out any rogue voxels that survived the integration. You can tune this via `tsdf_sor_nb_neighbors` (default `50`) and `tsdf_sor_std_ratio` (default `2.0`).
 > 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # ViPE: Video Pose Engine for Geometric 3D Perception (with Voxel-Aligned TSDF Integration)
 
-> **Fork Update:** This repository is a customized fork of NVIDIA's ViPE. It introduces **Voxel-Aligned TSDF Integration** utilizing Open3D to bypass the "Pixel-Aligned Trap" of standard dense depth unprojection. This ensures that overlapping fragmentation and view-bias are mathematically averaged out into a sparse, uniform point cloud (`.ply`). It can be enabled by setting `save_tsdf_ply: true` in the pipeline config (`configs/pipeline/default.yaml`).
+> **Fork Update:** This repository is a customized fork of NVIDIA's ViPE. It introduces **Voxel-Aligned TSDF Integration** utilizing Open3D to bypass the "Pixel-Aligned Trap" of standard dense depth unprojection. This ensures that overlapping fragmentation and view-bias are mathematically averaged out into a sparse, uniform point cloud (`.ply`). 
+>
+> In addition to the base TSDF fusion, this fork includes:
+> - **Dynamic Object Masking:** Leverages ViPE's dynamic masks to ignore moving objects, preventing "ghost" floaters in the static environment.
+> - **Depth Edge Pruning:** Calculates spatial gradients using Sobel operators and drops high-gradient pixels (to eliminate DA3's "comet tail" smearing over hard boundaries).
+> - **Statistical Outlier Removal (SOR):** Applies a final cleanup pass over the extracted point cloud to strip out any rogue voxels that survived the integration.
+> 
+> It can be enabled by setting `save_tsdf_ply: true` in the pipeline config (`configs/pipeline/default.yaml`).
 > 
 > *Changes made by nbardy.*
 

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -47,6 +47,22 @@ output:
 
   # Save point cloud using open3d scalable TSDF volume integration
   save_tsdf_ply: false
+  
+  # TSDF specific configurations (only used if save_tsdf_ply is true)
+  tsdf_voxel_length: 0.01
+  tsdf_sdf_trunc: 0.04
+  
+  # Dynamic Object Masking (zeroes out depth on moving objects like people, cars)
+  tsdf_apply_dynamic_mask: true
+  
+  # Depth Edge Pruning (drops depth discontinuity pixels to avoid flying pixels/comet tails)
+  tsdf_apply_edge_pruning: true
+  tsdf_edge_pruning_threshold: 0.5
+  
+  # Statistical Outlier Removal (cleans up floating noise in the final point cloud)
+  tsdf_apply_sor: true
+  tsdf_sor_nb_neighbors: 50
+  tsdf_sor_std_ratio: 2.0
 
   # Visualization videos to BASE_PATH/vipe/xxx.mp4
   save_viz: true

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -49,14 +49,18 @@ output:
   save_tsdf_ply: false
   
   # TSDF specific configurations (only used if save_tsdf_ply is true)
-  tsdf_voxel_length: 0.01
-  tsdf_sdf_trunc: 0.04
+  tsdf_voxel_length: 0.005
+  tsdf_sdf_trunc: 0.02
   
+  # Coordinate System: ViPE/Open3D use OpenCV (Y-down, Z-forward). Many Gaussian Splatting backends use OpenGL (Y-up).
+  # Set this to true to rotate the point cloud 180 degrees around the X-axis before saving.
+  tsdf_flip_x_axis: false
+
   # Dynamic Object Masking (zeroes out depth on moving objects like people, cars)
   tsdf_apply_dynamic_mask: true
   
   # Depth Edge Pruning (drops depth discontinuity pixels to avoid flying pixels/comet tails)
-  tsdf_apply_edge_pruning: true
+  tsdf_apply_edge_pruning: false
   tsdf_edge_pruning_threshold: 0.5
   
   # Statistical Outlier Removal (cleans up floating noise in the final point cloud)

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -54,8 +54,8 @@ output:
   tsdf_sdf_trunc: 0.04
   
   # Maximum depth (in meters) to integrate. 
-  # Pixels further than this are ignored. 10.0 is great for indoors. Try 20.0 or 50.0 for outdoors.
-  tsdf_depth_trunc: 10.0
+  # Set to a float (e.g. 10.0, 50.0) for a hard cutoff, or "auto" to dynamically truncate the furthest 5% of noisy depth pixels per frame.
+  tsdf_depth_trunc: "auto"
   # Set this to true to rotate the point cloud 180 degrees around the X-axis before saving.
   tsdf_flip_x_axis: false
 

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -49,8 +49,9 @@ output:
   save_tsdf_ply: false
   
   # TSDF specific configurations (only used if save_tsdf_ply is true)
-  tsdf_voxel_length: 0.005
-  tsdf_sdf_trunc: 0.02
+  # 0.01 (1cm) is the best "generalization" default. It handles large outdoor and small indoor scenes robustly without OOMing.
+  tsdf_voxel_length: 0.01
+  tsdf_sdf_trunc: 0.04
   
   # Coordinate System: ViPE/Open3D use OpenCV (Y-down, Z-forward). Many Gaussian Splatting backends use OpenGL (Y-up).
   # Set this to true to rotate the point cloud 180 degrees around the X-axis before saving.

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -59,9 +59,11 @@ output:
   # Dynamic Object Masking (zeroes out depth on moving objects like people, cars)
   tsdf_apply_dynamic_mask: true
   
-  # Depth Edge Pruning (drops depth discontinuity pixels to avoid flying pixels/comet tails)
+  # Relative Depth Pruning: Drops depth discontinuity pixels to avoid flying pixels/comet tails.
+  # Uses a relative percentage jump (e.g., 0.10 = 10% depth change) to preserve distant thin structures.
+  # Ablation options: 0.05 (Aggressive), 0.10 (Balanced), 0.20 (Relaxed - keeps thin wires)
   tsdf_apply_edge_pruning: true
-  tsdf_edge_pruning_threshold: 1.0
+  tsdf_pruning_threshold: 0.10
   
   # Statistical Outlier Removal (cleans up floating noise in the final point cloud)
   tsdf_apply_sor: true

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -53,7 +53,9 @@ output:
   tsdf_voxel_length: 0.01
   tsdf_sdf_trunc: 0.04
   
-  # Coordinate System: ViPE/Open3D use OpenCV (Y-down, Z-forward). Many Gaussian Splatting backends use OpenGL (Y-up).
+  # Maximum depth (in meters) to integrate. 
+  # Pixels further than this are ignored. 10.0 is great for indoors. Try 20.0 or 50.0 for outdoors.
+  tsdf_depth_trunc: 10.0
   # Set this to true to rotate the point cloud 180 degrees around the X-axis before saving.
   tsdf_flip_x_axis: false
 

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -45,6 +45,9 @@ output:
   # Save reconstruction from SLAM
   save_slam_map: false
 
+  # Save point cloud using open3d scalable TSDF volume integration
+  save_tsdf_ply: false
+
   # Visualization videos to BASE_PATH/vipe/xxx.mp4
   save_viz: true
   viz_downsample: 2

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -22,6 +22,8 @@ init:
       - car
       - bus
     add_sky: true
+    track_downscale: 1
+    track_stride: 1
 
 slam:
   keyframe_depth: unidepth-l

--- a/configs/pipeline/default.yaml
+++ b/configs/pipeline/default.yaml
@@ -60,8 +60,8 @@ output:
   tsdf_apply_dynamic_mask: true
   
   # Depth Edge Pruning (drops depth discontinuity pixels to avoid flying pixels/comet tails)
-  tsdf_apply_edge_pruning: false
-  tsdf_edge_pruning_threshold: 0.5
+  tsdf_apply_edge_pruning: true
+  tsdf_edge_pruning_threshold: 1.0
   
   # Statistical Outlier Removal (cleans up floating noise in the final point cloud)
   tsdf_apply_sor: true

--- a/configs/pipeline/motion_aware.yaml
+++ b/configs/pipeline/motion_aware.yaml
@@ -1,0 +1,17 @@
+defaults:
+  - default
+  - _self_
+
+# Replace text-prompted TrackAnything with motion-driven dynamic-mask estimation.
+init:
+  instance:
+    mode: motion
+    sam_points_per_side: 16
+    keep_motion_ratio: 0.15
+    flow_alpha: 0.5
+    flow_beta: 0.5
+    # `phrases`/`add_sky` are kept from default config for compatibility but ignored in motion mode.
+
+output:
+  save_viz: true
+  viz_attributes: [['rgb', 'instance', 'mask'], ['depth', 'pcd']]

--- a/configs/pipeline/pose_only.yaml
+++ b/configs/pipeline/pose_only.yaml
@@ -1,0 +1,46 @@
+defaults:
+  - /slam: default
+
+instance: vipe.pipeline.pose_only.PoseOnlyAnnotationPipeline
+
+# Init configs (same as the default pipeline: instance masks are kept because
+# they reject dynamic objects during SLAM and hence affect pose accuracy).
+init:
+  camera_type: "pinhole"
+  intrinsics: "geocalib"
+  async_prefetch: true
+  prefetch_queue_size: 16
+  instance:
+    kf_gap_sec: 2.0
+    phrases:
+      - person
+      - animal
+      - vehicle
+      - ball
+      - balloon
+      - gun
+      - pet
+      - car
+      - bus
+    add_sky: true
+    # Track at half resolution: SLAM only consumes masks at 1/8 resolution, so
+    # this is nearly free in accuracy but much faster. Set track_stride: 2 for
+    # additional speed, or instance: null for the fastest (static scenes only).
+    track_downscale: 2
+    track_stride: 1
+
+slam:
+  # Keyframe-only metric depth prior. This anchors the metric scale of the
+  # trajectory and is much cheaper than per-frame dense depth.
+  keyframe_depth: unidepth-l
+  optimize_intrinsics: ${neq:${..init.intrinsics},"gt"}
+
+# Output configs: poses/intrinsics only, no depth or visualization work.
+output:
+  path: vipe_results/
+  skip_exists: false
+  save_artifacts: true
+  save_slam_map: false
+  save_viz: false
+  viz_downsample: 2
+  viz_attributes: [['rgb']]

--- a/configs/pipeline/sana_wm_pi3x_moge2.yaml
+++ b/configs/pipeline/sana_wm_pi3x_moge2.yaml
@@ -1,0 +1,19 @@
+# SANA-WM 增强版 pipeline（pi3x_moge2 后端）
+# 与 sana_wm_pose_only.yaml 的唯一区别：两处深度后端改为 pi3x_moge2
+defaults:
+  - default
+
+init:
+  instance: null
+
+slam:
+  keyframe_depth: pi3x_moge2
+
+post:
+  depth_align_model: adaptive_pi3x-moge2
+
+output:
+  save_viz: false
+  save_artifacts: true
+  viz_downsample: 2
+  viz_attributes: [['rgb']]

--- a/configs/pipeline/sana_wm_pi3x_moge2_full.yaml
+++ b/configs/pipeline/sana_wm_pi3x_moge2_full.yaml
@@ -1,0 +1,23 @@
+# SANA-WM full Pi3X+MoGe-2 pipeline (Plan A: video-batch depth).
+# SLAM uses unidepth-l (same as sana_wm_pose_only for fair comparison).
+# Post uses VideoPi3XDepthProcessor: collects ALL frames, runs Pi3X in 16-frame
+# chunks for sequence-consistent depth, MoGe-2 for metric scale, EMA fusion.
+#
+# Requires: SANA_WM_PI3X_WEIGHTS + SANA_WM_MOGE2_WEIGHTS
+defaults:
+  - default
+
+init:
+  instance: null
+
+slam:
+  keyframe_depth: unidepth-l
+
+post:
+  depth_align_model: video_pi3x_moge2
+
+output:
+  save_viz: false
+  save_artifacts: true
+  viz_downsample: 2
+  viz_attributes: [['rgb']]

--- a/configs/pipeline/sana_wm_pose_only.yaml
+++ b/configs/pipeline/sana_wm_pose_only.yaml
@@ -1,0 +1,24 @@
+# SANA-WM pose-annotation pipeline config (App. B.1).
+# Minimal: no instance segmentation, no visualization.
+# Use:  vipe infer <video> -o <out> --pipeline sana_wm_pose_only
+#
+# Depth backend precedence:
+#   pi3x_moge2  — paper-aligned (requires SANA_WM_PI3X_WEIGHTS + SANA_WM_MOGE2_WEIGHTS)
+#   unidepth-l  — fallback smoke/debug mode (no extra weights needed beyond VIPE)
+defaults:
+  - default
+
+init:
+  instance: null        # skip segmentation (not needed for pose annotation)
+
+slam:
+  keyframe_depth: unidepth-l   # changed to pi3x_moge2 once weights registered
+
+post:
+  depth_align_model: "adaptive_unidepth-l"   # changed to pi3x_moge2 for full pipeline
+
+output:
+  save_viz: false       # no visualization videos
+  save_artifacts: true  # write pose/intrinsics/depth npz
+  viz_downsample: 2
+  viz_attributes: [['rgb']]

--- a/configs/pipeline/vipe_cached_depth.yaml
+++ b/configs/pipeline/vipe_cached_depth.yaml
@@ -1,0 +1,38 @@
+defaults:
+  - /slam: default
+  - _self_
+
+instance: vipe.pipeline.default.DefaultAnnotationPipeline
+
+init:
+  camera_type: "pinhole"
+  intrinsics: "geocalib"
+  instance:
+    kf_gap_sec: 2.0
+    phrases:
+      - person
+      - animal
+      - vehicle
+      - ball
+      - balloon
+      - gun
+      - pet
+      - car
+      - bus
+    add_sky: true
+
+slam:
+  keyframe_depth: cached
+  optimize_intrinsics: ${neq:${..init.intrinsics},"gt"}
+
+post:
+  depth_align_model: null
+
+output:
+  path: vipe_results/
+  skip_exists: false
+  save_artifacts: true
+  save_slam_map: false
+  save_viz: false
+  viz_downsample: 2
+  viz_attributes: [['rgb', 'instance'], ['depth', 'pcd']]

--- a/configs/pipeline/vipe_metric3d_small.yaml
+++ b/configs/pipeline/vipe_metric3d_small.yaml
@@ -1,0 +1,38 @@
+defaults:
+  - /slam: default
+  - _self_
+
+instance: vipe.pipeline.default.DefaultAnnotationPipeline
+
+init:
+  camera_type: "pinhole"
+  intrinsics: "geocalib"
+  instance:
+    kf_gap_sec: 2.0
+    phrases:
+      - person
+      - animal
+      - vehicle
+      - ball
+      - balloon
+      - gun
+      - pet
+      - car
+      - bus
+    add_sky: true
+
+slam:
+  keyframe_depth: metric3d-small
+  optimize_intrinsics: ${neq:${..init.intrinsics},"gt"}
+
+post:
+  depth_align_model: null
+
+output:
+  path: vipe_results/
+  skip_exists: false
+  save_artifacts: true
+  save_slam_map: false
+  save_viz: false
+  viz_downsample: 2
+  viz_attributes: [['rgb', 'instance'], ['depth', 'pcd']]

--- a/convert_vipe_to_gen3c.py
+++ b/convert_vipe_to_gen3c.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+ViPE to GEN3C Format Converter
+
+This script converts ViPE output format to GEN3C input format.
+ViPE outputs data in separate subdirectories with specific formats,
+while GEN3C expects a unified directory structure.
+"""
+
+import numpy as np
+import cv2
+import zipfile
+import OpenEXR
+import Imath
+from pathlib import Path
+import shutil
+import argparse
+import logging
+from typing import Optional
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def read_vipe_depth_data(depth_zip_path: Path) -> np.ndarray:
+    """
+    Read depth data from ViPE's ZIP file containing EXR files.
+    
+    Args:
+        depth_zip_path: Path to the depth.zip file
+        
+    Returns:
+        numpy array of shape [T, H, W] with depth values
+    """
+    depth_arrays = []
+    
+    with zipfile.ZipFile(depth_zip_path, "r") as z:
+        for file_name in sorted(z.namelist()):
+            frame_idx = int(file_name.split(".")[0])
+            with z.open(file_name) as f:
+                try:
+                    exr = OpenEXR.InputFile(f)
+                    header = exr.header()
+                    dw = header["dataWindow"]
+                    width = dw.max.x - dw.min.x + 1
+                    height = dw.max.y - dw.min.y + 1
+                    channels = exr.channels(["Z"])
+                    depth_data = np.frombuffer(channels[0], dtype=np.float16)
+                    depth_data = depth_data.reshape((height, width)).astype(np.float32)
+                    depth_arrays.append(depth_data)
+                    logger.debug(f"Loaded depth frame {frame_idx}: {width}x{height}")
+                except Exception as e:
+                    logger.warning(f"Failed to load depth frame {file_name}: {e}")
+                    # Create a dummy depth map filled with NaN
+                    if depth_arrays:
+                        h, w = depth_arrays[-1].shape
+                        depth_arrays.append(np.full((h, w), np.nan, dtype=np.float32))
+                    else:
+                        raise ValueError("Cannot determine depth map dimensions")
+    
+    return np.stack(depth_arrays, axis=0)
+
+
+def read_vipe_mask_data(mask_zip_path: Path) -> np.ndarray:
+    """
+    Read mask data from ViPE's ZIP file containing PNG files.
+    
+    Args:
+        mask_zip_path: Path to the mask.zip file
+        
+    Returns:
+        numpy array of shape [T, H, W] with mask values
+    """
+    mask_arrays = []
+    
+    with zipfile.ZipFile(mask_zip_path, "r") as z:
+        for file_name in sorted(z.namelist()):
+            frame_idx = int(file_name.split(".")[0])
+            with z.open(file_name) as f:
+                try:
+                    mask_buffer = np.frombuffer(f.read(), dtype=np.uint8)
+                    mask = cv2.imdecode(mask_buffer, cv2.IMREAD_UNCHANGED)
+                    if mask is None:
+                        raise ValueError(f"Failed to decode PNG mask {file_name}")
+                    mask_arrays.append(mask.astype(np.float32))
+                    logger.debug(f"Loaded mask frame {frame_idx}: {mask.shape}")
+                except Exception as e:
+                    logger.warning(f"Failed to load mask frame {file_name}: {e}")
+                    # Create a dummy mask filled with ones
+                    if mask_arrays:
+                        h, w = mask_arrays[-1].shape[:2]
+                        mask_arrays.append(np.ones((h, w), dtype=np.float32))
+                    else:
+                        raise ValueError("Cannot determine mask dimensions")
+    
+    return np.stack(mask_arrays, axis=0)
+
+
+def convert_intrinsics_to_matrix(fx: float, fy: float, cx: float, cy: float) -> np.ndarray:
+    """
+    Convert intrinsic parameters to 3x3 matrix format.
+    
+    Args:
+        fx, fy: Focal lengths
+        cx, cy: Principal point coordinates
+        
+    Returns:
+        3x3 intrinsics matrix
+    """
+    return np.array([
+        [fx, 0, cx],
+        [0, fy, cy],
+        [0, 0, 1]
+    ], dtype=np.float32)
+
+
+def interpolate_sparse_data(data: np.ndarray, indices: np.ndarray, target_length: int) -> np.ndarray:
+    """
+    Interpolate sparse data to fill all frames.
+    
+    Args:
+        data: Data array with shape [N, ...]
+        indices: Frame indices corresponding to data
+        target_length: Total number of frames needed
+        
+    Returns:
+        Interpolated data array with shape [target_length, ...]
+    """
+    if len(data) == 0:
+        raise ValueError("No data to interpolate")
+    
+    result = []
+    for i in range(target_length):
+        if i in indices:
+            # Use exact data
+            idx = np.where(indices == i)[0][0]
+            result.append(data[idx])
+        else:
+            # Find nearest available data
+            if i < indices[0]:
+                # Use first available
+                result.append(data[0])
+            elif i > indices[-1]:
+                # Use last available
+                result.append(data[-1])
+            else:
+                # Interpolate between nearest neighbors
+                prev_idx = np.where(indices < i)[0][-1]
+                next_idx = np.where(indices > i)[0][0]
+                
+                # Simple linear interpolation for matrices
+                alpha = (i - indices[prev_idx]) / (indices[next_idx] - indices[prev_idx])
+                interpolated = (1 - alpha) * data[prev_idx] + alpha * data[next_idx]
+                result.append(interpolated)
+    
+    return np.stack(result, axis=0)
+
+
+def convert_vipe_to_gen3c(vipe_dir: str, output_dir: str, video_name: Optional[str] = None) -> Path:
+    """
+    Convert ViPE output format to GEN3C input format.
+    
+    Args:
+        vipe_dir: Path to ViPE output directory
+        output_dir: Path to output directory for GEN3C format
+        video_name: Optional specific video name to convert (if None, uses first found)
+        
+    Returns:
+        Path to the converted output directory
+    """
+    vipe_path = Path(vipe_dir)
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    
+    logger.info(f"Converting ViPE output from {vipe_dir} to {output_dir}")
+    
+    # Find video files
+    rgb_files = list((vipe_path / "rgb").glob("*.mp4"))
+    if not rgb_files:
+        raise FileNotFoundError(f"No MP4 files found in {vipe_path / 'rgb'}")
+    
+    # If video_name specified, find matching file
+    if video_name:
+        matching_files = [f for f in rgb_files if video_name in f.stem]
+        if not matching_files:
+            raise FileNotFoundError(f"No video file found matching '{video_name}'")
+        rgb_file = matching_files[0]
+        base_name = rgb_file.stem
+    else:
+        rgb_file = rgb_files[0]
+        base_name = rgb_file.stem
+    
+    logger.info(f"Converting video: {base_name}")
+    
+    # 1. Copy RGB video (rename to standard name)
+    logger.info("Copying RGB video...")
+    shutil.copy(rgb_file, output_path / "rgb.mp4")
+    
+    # 2. Convert depth data
+    depth_files = list((vipe_path / "depth").glob(f"{base_name}.zip"))
+    if depth_files:
+        logger.info("Converting depth data...")
+        depth_stack = read_vipe_depth_data(depth_files[0])
+        np.savez_compressed(output_path / "depth.npz", depth=depth_stack)
+        num_frames = len(depth_stack)
+        logger.info(f"Converted {num_frames} depth frames")
+    else:
+        logger.warning("No depth data found")
+        num_frames = None
+    
+    # 3. Convert camera parameters
+    pose_files = list((vipe_path / "pose").glob(f"{base_name}.npz"))
+    intrinsics_files = list((vipe_path / "intrinsics").glob(f"{base_name}.npz"))
+    
+    if pose_files and intrinsics_files:
+        logger.info("Converting camera parameters...")
+        
+        # Load pose data
+        pose_data = np.load(pose_files[0])
+        w2c_matrices = pose_data['data']  # [N, 4, 4]
+        pose_inds = pose_data['inds']
+        
+        # Load intrinsics data
+        intr_data = np.load(intrinsics_files[0])
+        intr_params = intr_data['data']  # [N, 4] - fx, fy, cx, cy
+        intr_inds = intr_data['inds']
+        
+        # Determine number of frames
+        if num_frames is None:
+            # Use the maximum index from camera data + 1
+            num_frames = max(pose_inds.max(), intr_inds.max()) + 1
+            logger.info(f"Inferred {num_frames} frames from camera data")
+        
+        # Interpolate poses to fill all frames
+        full_w2c = interpolate_sparse_data(w2c_matrices, pose_inds, num_frames)
+        
+        # Convert and interpolate intrinsics
+        intr_matrices = np.array([convert_intrinsics_to_matrix(*params) for params in intr_params])
+        full_intrinsics = interpolate_sparse_data(intr_matrices, intr_inds, num_frames)
+        
+        # Save combined camera parameters
+        np.savez(output_path / "camera.npz",
+                 w2c=full_w2c.astype(np.float32),
+                 intrinsics=full_intrinsics.astype(np.float32))
+        
+        logger.info(f"Converted camera parameters for {num_frames} frames")
+    else:
+        raise FileNotFoundError("Missing pose or intrinsics files")
+    
+    # 4. Convert mask data (optional)
+    mask_files = list((vipe_path / "mask").glob(f"{base_name}.zip"))
+    if mask_files:
+        logger.info("Converting mask data...")
+        mask_stack = read_vipe_mask_data(mask_files[0])
+        np.savez_compressed(output_path / "mask.npz", mask=mask_stack)
+        logger.info(f"Converted {len(mask_stack)} mask frames")
+    else:
+        logger.info("No mask data found, creating default masks...")
+        # Create default masks (all ones)
+        if num_frames and 'depth_stack' in locals():
+            _, h, w = depth_stack.shape
+            default_mask = np.ones((num_frames, h, w), dtype=np.float32)
+            np.savez_compressed(output_path / "mask.npz", mask=default_mask)
+    
+    logger.info(f"Conversion completed successfully: {vipe_dir} -> {output_dir}")
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert ViPE output to GEN3C input format")
+    parser.add_argument("vipe_dir", help="Path to ViPE output directory")
+    parser.add_argument("output_dir", help="Path to output directory for GEN3C format")
+    parser.add_argument("--video-name", help="Specific video name to convert (optional)")
+    parser.add_argument("--run-gen3c", action="store_true", help="Run GEN3C after conversion")
+    parser.add_argument("--trajectory", default="up", choices=[
+        "left", "right", "up", "down", "zoom_in", "zoom_out", "clockwise", "counterclockwise"
+    ], help="Camera trajectory for GEN3C (default: up)")
+    parser.add_argument("--movement-distance", type=float, default=0.5, 
+                       help="Camera movement distance (default: 0.5)")
+    parser.add_argument("--camera-rotation", default="center_facing", 
+                       choices=["center_facing", "no_rotation", "trajectory_aligned"],
+                       help="Camera rotation mode (default: center_facing)")
+    parser.add_argument("--checkpoint-dir", default="GEN3C/checkpoints",
+                       help="GEN3C checkpoint directory")
+    parser.add_argument("--video-save-name", default="converted_output",
+                       help="Output video name for GEN3C")
+    
+    args = parser.parse_args()
+    
+    try:
+        # Convert format
+        converted_path = convert_vipe_to_gen3c(args.vipe_dir, args.output_dir, args.video_name)
+        
+        if args.run_gen3c:
+            logger.info("Running GEN3C with converted data...")
+            import subprocess
+            
+            cmd = [
+                "python", "GEN3C/cosmos_predict1/diffusion/inference/gen3c_dynamic.py",
+                "--checkpoint_dir", args.checkpoint_dir,
+                "--input_image_path", str(converted_path),
+                "--video_save_name", args.video_save_name,
+                "--trajectory", args.trajectory,
+                "--movement_distance", str(args.movement_distance),
+                "--camera_rotation", args.camera_rotation,
+                "--guidance", "1"
+            ]
+            
+            logger.info(f"Running command: {' '.join(cmd)}")
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            
+            if result.returncode == 0:
+                logger.info("GEN3C completed successfully!")
+                logger.info(f"Output: {result.stdout}")
+            else:
+                logger.error(f"GEN3C failed with return code {result.returncode}")
+                logger.error(f"Error: {result.stderr}")
+        
+    except Exception as e:
+        logger.error(f"Conversion failed: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -19,6 +19,7 @@ These are the pipeline values accepted by `pipeline=...` in Hydra overrides and 
 | Preset | Purpose | Pipeline Class | Camera | Keyframe Depth | Depth Post-Processing |
 | --- | --- | --- | --- | --- | --- |
 | `default` | Default pipeline for pinhole videos. | `DefaultAnnotationPipeline` | `pinhole` | `unidepth-l` | `adaptive_unidepth-l_svda` |
+| `pose_only` | Fast pose-only pipeline that skips all per-frame dense depth estimation. | `PoseOnlyAnnotationPipeline` | `pinhole` | `unidepth-l` | `null` |
 | `dav3` | Default pipeline using Depth Anything 3 for keyframe and multiview depth. | `DefaultAnnotationPipeline` | `pinhole` | `dav3` | `mvd_dav3` |
 | `lyra` | Configuration used for Lyra-style results, with MoGe keyframe depth and VDA alignment. | `DefaultAnnotationPipeline` | `pinhole` | `moge` | `adaptive_moge_vda` |
 | `no_vda` | Default pipeline without Video Depth Anything alignment. | `DefaultAnnotationPipeline` | `pinhole` | `unidepth-l` | `adaptive_unidepth-l` |
@@ -44,7 +45,7 @@ Top-level ViPE runtime configuration.
 | Field | Type | Default | Constraints | Description |
 | --- | --- | --- | --- | --- |
 | `streams` | RawMP4StreamListConfig \| FrameDirStreamListConfig | required | - | Input stream list that supplies videos or frame directories to process. |
-| `pipeline` | DefaultPipelineConfig \| PanoramaPipelineConfig | required | - | Annotation pipeline and all pipeline-specific runtime options. |
+| `pipeline` | DefaultPipelineConfig \| PoseOnlyPipelineConfig \| PanoramaPipelineConfig | required | - | Annotation pipeline and all pipeline-specific runtime options. |
 
 ## Input Streams
 
@@ -97,6 +98,8 @@ Object and sky-mask initialization used by the segmentation stage.
 | `kf_gap_sec` | float | required | > 0.0 | Minimum time gap, in seconds, between keyframes used to initialize instance segmentation. |
 | `phrases` | list[str] | required | min items 1 | Text prompts passed to the open-vocabulary detector for objects that should be segmented. |
 | `add_sky` | bool | required | - | Add a sky mask to the instance segmentation output when the detector supports it. |
+| `track_downscale` | int | `1` | >= 1 | Downscale factor applied to frames before instance tracking. Values above 1 speed up tracking considerably; masks are upsampled back to full resolution. |
+| `track_stride` | int | `1` | >= 1 | Track instances only every N-th frame and reuse the previous mask in between. Values above 1 speed up tracking at the cost of slightly stale masks on in-between frames. |
 
 ### DefaultInitConfig
 
@@ -164,6 +167,17 @@ Default annotation pipeline for pinhole and wide-angle videos.
 | `slam` | SLAMConfig | required | - | SLAM and bundle-adjustment configuration. |
 | `post` | PostConfig | required | - | Depth alignment and post-processing configuration. |
 | `output` | OutputConfig | required | - | Output artifact and visualization configuration. |
+
+### PoseOnlyPipelineConfig
+
+Fast pose-only pipeline: per-frame camera poses and intrinsics without dense depth.
+
+| Field | Type | Default | Constraints | Description |
+| --- | --- | --- | --- | --- |
+| `instance` | `vipe.pipeline.pose_only.PoseOnlyAnnotationPipeline` | required | fixed `vipe.pipeline.pose_only.PoseOnlyAnnotationPipeline` | Implementation class for the pose-only annotation pipeline. |
+| `init` | DefaultInitConfig | required | - | Initial camera and instance-mask setup. |
+| `slam` | SLAMConfig | required | - | SLAM and bundle-adjustment configuration. |
+| `output` | OutputConfig | required | - | Output artifact configuration (visualization options are ignored). |
 
 ### PanoramaPipelineConfig
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,7 @@ ViPE currently supports these pipeline presets:
 | Preset | Use case |
 | --- | --- |
 | `default` | Default pipeline for pinhole cameras. |
+| `pose_only` | Fast pose-only estimation for pinhole cameras (~4x faster than `default`). Skips all per-frame dense depth work, tracks instance masks at half resolution, and only writes pose and intrinsics artifacts; the recovered trajectory matches the `default` pipeline. For further speed set `pipeline.init.instance.track_stride=2` (strided mask tracking) or `pipeline.init.instance=null` (no masks; static scenes only). |
 | `lyra` | Configuration for results in the [Lyra](https://github.com/nv-tlabs/lyra) paper. |
 | `dav3` | Uses Depth Anything 3 for depth estimation. |
 | `no_vda` | Skips Video Depth Anything alignment when it is too memory-consuming. |

--- a/scripts/compare_pose_artifacts.py
+++ b/scripts/compare_pose_artifacts.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Compare two pose artifact npz files (as written by ViPE pipelines).
+
+Reports ATE (after Sim3 alignment) and relative rotation error so that a
+faster pipeline can be validated against the default pipeline's trajectory.
+
+Usage: python scripts/compare_pose_artifacts.py ref_pose.npz test_pose.npz
+"""
+
+import argparse
+import sys
+
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from vipe.utils.io import read_pose_artifacts
+
+
+def umeyama_align(source: np.ndarray, target: np.ndarray) -> tuple[float, np.ndarray, np.ndarray]:
+    """Return (s, R, t) minimizing ||target - (s * R @ source + t)||^2."""
+    mu_s, mu_t = source.mean(0), target.mean(0)
+    xs, xt = source - mu_s, target - mu_t
+    cov = xt.T @ xs / len(source)
+    U, D, Vt = np.linalg.svd(cov)
+    S = np.eye(3)
+    if np.linalg.det(U) * np.linalg.det(Vt) < 0:
+        S[2, 2] = -1
+    R = U @ S @ Vt
+    s = np.trace(np.diag(D) @ S) / (xs**2).sum(1).mean()
+    t = mu_t - s * R @ mu_s
+    return float(s), R, t
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ref", type=Path, help="Reference pose npz (e.g. default pipeline output)")
+    parser.add_argument("test", type=Path, help="Test pose npz (e.g. pose-only pipeline output)")
+    args = parser.parse_args()
+
+    ref_inds, ref_traj = read_pose_artifacts(args.ref)
+    test_inds, test_traj = read_pose_artifacts(args.test)
+
+    common, ref_pos, test_pos = np.intersect1d(ref_inds, test_inds, return_indices=True)
+    assert len(common) > 0, "No common frame indices between the two trajectories"
+    ref_mat = ref_traj.matrix().cpu().numpy()[ref_pos]
+    test_mat = test_traj.matrix().cpu().numpy()[test_pos]
+    print(f"Comparing {len(common)} common frames")
+
+    # Sim3-align test onto ref (pose accuracy is defined up to a global similarity).
+    s, R, t = umeyama_align(test_mat[:, :3, 3], ref_mat[:, :3, 3])
+    ref_t = ref_mat[:, :3, 3]
+    test_t = (s * (R @ test_mat[:, :3, 3].T)).T + t
+    ate = np.linalg.norm(ref_t - test_t, axis=-1)
+
+    # Rotation error via frame-to-frame relative rotations, which are invariant
+    # to the global alignment.
+    ref_rot = ref_mat[:, :3, :3]
+    test_rot = test_mat[:, :3, :3]
+    rel_ref = np.einsum("nij,nik->njk", ref_rot[:-1], ref_rot[1:])
+    rel_test = np.einsum("nij,nik->njk", test_rot[:-1], test_rot[1:])
+    rel_err = np.einsum("nij,nik->njk", rel_ref, rel_test)
+    cos = np.clip((np.trace(rel_err, axis1=1, axis2=2) - 1.0) / 2.0, -1.0, 1.0)
+    rot_err_deg = np.degrees(np.arccos(cos))
+
+    traj_extent = float(np.linalg.norm(ref_t.max(0) - ref_t.min(0)))
+    print(f"Trajectory extent (ref): {traj_extent:.4f} m")
+    print(f"ATE  RMSE: {np.sqrt((ate**2).mean()):.6f} m | mean: {ate.mean():.6f} | max: {ate.max():.6f}")
+    print(f"Rot  mean: {rot_err_deg.mean():.6f} deg | max: {rot_err_deg.max():.6f} deg")
+    if traj_extent > 0:
+        print(f"ATE RMSE / extent: {100.0 * np.sqrt((ate**2).mean()) / traj_extent:.4f} %")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -24,6 +24,7 @@ from vipe.config.pipeline import (
     OutputConfig,
     PanoramaInitConfig,
     PanoramaPipelineConfig,
+    PoseOnlyPipelineConfig,
     PostConfig,
     VirtualCameraConfig,
 )
@@ -47,6 +48,7 @@ MODEL_SECTIONS: list[tuple[str, list[type[BaseConfigSchema]]]] = [
             PostConfig,
             OutputConfig,
             DefaultPipelineConfig,
+            PoseOnlyPipelineConfig,
             PanoramaPipelineConfig,
         ],
     ),
@@ -55,6 +57,7 @@ MODEL_SECTIONS: list[tuple[str, list[type[BaseConfigSchema]]]] = [
 
 PIPELINE_PURPOSES = {
     "default": "Default pipeline for pinhole videos.",
+    "pose_only": "Fast pose-only pipeline that skips all per-frame dense depth estimation.",
     "dav3": "Default pipeline using Depth Anything 3 for keyframe and multiview depth.",
     "lyra": "Configuration used for Lyra-style results, with MoGe keyframe depth and VDA alignment.",
     "no_vda": "Default pipeline without Video Depth Anything alignment.",
@@ -62,7 +65,7 @@ PIPELINE_PURPOSES = {
     "wide_angle": "Default pipeline configured for wide-angle or fisheye input.",
     "panorama": "Panorama pipeline that projects 360-degree frames into virtual perspective views.",
 }
-PIPELINE_PRESET_ORDER = ["default", "dav3", "lyra", "no_vda", "static_vda", "wide_angle", "panorama"]
+PIPELINE_PRESET_ORDER = ["default", "pose_only", "dav3", "lyra", "no_vda", "static_vda", "wide_angle", "panorama"]
 
 
 def _escape_table_cell(value: str) -> str:

--- a/scripts/tsdf_ablation.py
+++ b/scripts/tsdf_ablation.py
@@ -1,0 +1,98 @@
+import argparse
+import itertools
+import shutil
+import subprocess
+from pathlib import Path
+
+def main():
+    parser = argparse.ArgumentParser(description="Run a TSDF hyperparameter ablation study using ViPE.")
+    parser.add_argument("video_path", type=str, help="Path to the input video file (e.g., input.mp4)")
+    parser.add_argument("--output_dir", type=str, default="ablation_results", help="Directory to store the resulting .ply files")
+    args = parser.parse_args()
+
+    video_path = Path(args.video_path)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    video_name = video_path.stem
+
+    # Define the parameter grid to test
+    grid = {
+        "voxel_length": [0.005, 0.01],
+        "pruning_threshold": [None, 0.05, 0.10, 0.20], # None means apply_edge_pruning=False
+        "dynamic_mask": [True, False]
+    }
+
+    keys = grid.keys()
+    combinations = list(itertools.product(*grid.values()))
+    
+    print(f"Starting ablation study for {video_name}.")
+    print(f"Total combinations to test: {len(combinations)}
+")
+
+    for idx, combo in enumerate(combinations, 1):
+        params = dict(zip(keys, combo))
+        
+        # Construct the unique identifier for this run
+        voxel_str = f"Voxel{params['voxel_length']}"
+        prune_str = "NoPrune" if params['pruning_threshold'] is None else f"Prune{params['pruning_threshold']}"
+        mask_str = "MaskOn" if params['dynamic_mask'] else "MaskOff"
+        run_id = f"{voxel_str}_{prune_str}_{mask_str}"
+        
+        # Temporary output directory for this specific vipe run
+        run_out_dir = output_dir / f"tmp_{run_id}"
+        
+        print(f"[{idx}/{len(combinations)}] Running: {run_id}")
+        
+        # Build Hydra overrides
+        cmd = [
+            "vipe",
+            "--video_path", str(video_path),
+            "pipeline.output.save_tsdf_ply=true",
+            f"pipeline.output.path={run_out_dir}",
+            f"pipeline.output.tsdf_voxel_length={params['voxel_length']}",
+            # Rule of thumb: sdf_trunc should be ~4x voxel_length
+            f"pipeline.output.tsdf_sdf_trunc={params['voxel_length'] * 4.0}",
+            f"pipeline.output.tsdf_apply_dynamic_mask={str(params['dynamic_mask']).lower()}"
+        ]
+        
+        if params['pruning_threshold'] is None:
+            cmd.append("pipeline.output.tsdf_apply_edge_pruning=false")
+        else:
+            cmd.append("pipeline.output.tsdf_apply_edge_pruning=true")
+            cmd.append(f"pipeline.output.tsdf_pruning_threshold={params['pruning_threshold']}")
+
+        # Execute ViPE
+        try:
+            subprocess.run(cmd, check=True)
+            
+            # The resulting TSDF ply will be deeply nested in the run_out_dir:
+            # run_out_dir / "vipe" / f"{video_name}_tsdf.ply" (based on default ArtifactPath)
+            expected_ply = run_out_dir / video_name / "vipe" / f"{video_name}_tsdf.ply"
+            
+            # ViPE artifact paths often have a subfolder with the artifact_name (which is video_name)
+            if not expected_ply.exists():
+                 # Fallback search if artifact path structure differs
+                 found_plys = list(run_out_dir.rglob("*_tsdf.ply"))
+                 if found_plys:
+                     expected_ply = found_plys[0]
+            
+            if expected_ply.exists():
+                final_ply_path = output_dir / f"{video_name}_{run_id}.ply"
+                shutil.copy(expected_ply, final_ply_path)
+                print(f"  -> Saved: {final_ply_path.name}")
+            else:
+                print(f"  -> Warning: Could not find resulting .ply file for {run_id}")
+                
+        except subprocess.CalledProcessError as e:
+            print(f"  -> Error executing ViPE for {run_id}: {e}")
+        finally:
+            # Cleanup the heavy temporary ViPE artifacts to save disk space
+            if run_out_dir.exists():
+                shutil.rmtree(run_out_dir)
+
+    print("
+✅ Ablation study complete!")
+    print(f"All generated .ply files are available in: {output_dir.absolute()}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_track_anything_processor.py
+++ b/tests/test_track_anything_processor.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+from vipe.pipeline.processors import TrackAnythingProcessor
+from vipe.streams.base import VideoFrame
+
+
+class _FakeTracker:
+    """Mimics TrackAnythingPipeline's batching/tracking interface."""
+
+    def __init__(self, sam_run_gap: int) -> None:
+        self.sam_run_gap = sam_run_gap
+        self.frame_idx = 0
+        self.tracked_sizes: list[tuple[int, int]] = []
+        self.encoded_batches: list[int] = []
+
+    def should_batch_aot_frame(self, pending_frame_count: int = 0) -> bool:
+        frame_idx = self.frame_idx + pending_frame_count
+        return frame_idx > 0 and frame_idx % self.sam_run_gap != 0
+
+    def encode_aot_frames(self, frame_data_list):
+        self.encoded_batches.append(len(frame_data_list))
+        return [None] * len(frame_data_list)
+
+    def track(self, frame_data, aot_img_embs=None):
+        self.tracked_sizes.append(frame_data.size())
+        self.frame_idx += 1
+        # Instance id equals the number of tracked frames so far, so each
+        # output frame records which tracker invocation produced its mask.
+        instance = torch.full(frame_data.size(), self.frame_idx, dtype=torch.uint8)
+        return instance, {0: "background"}
+
+
+def _make_processor(track_downscale: int, track_stride: int, sam_run_gap: int, batch_size: int):
+    processor = TrackAnythingProcessor.__new__(TrackAnythingProcessor)
+    processor.mask_phrases = ["person"]
+    processor.add_sky = False
+    processor.track_downscale = track_downscale
+    processor.track_stride = track_stride
+    processor.sam_run_gap = max(1, sam_run_gap // track_stride)
+    processor.tracker = _FakeTracker(processor.sam_run_gap)
+    processor.mask_expand = 1
+    processor.aot_encoder_batch_size = batch_size
+    processor._last_instance = None
+    processor._last_phrases = None
+    processor._last_mask = None
+    return processor
+
+
+def _frames(n: int, size=(16, 24)):
+    return [VideoFrame(raw_frame_idx=i, rgb=torch.rand(*size, 3)) for i in range(n)]
+
+
+def _run(processor, frames):
+    out = list(processor.update_iterator(iter(frames), 0))
+    return out
+
+
+def test_plain_processing_matches_frame_count_and_order():
+    processor = _make_processor(track_downscale=1, track_stride=1, sam_run_gap=4, batch_size=3)
+    out = _run(processor, _frames(11))
+    assert [f.raw_frame_idx for f in out] == list(range(11))
+    assert all(f.instance is not None and f.mask is not None for f in out)
+    # Every frame tracked individually.
+    assert processor.tracker.frame_idx == 11
+
+
+def test_stride_reuses_previous_mask_in_order():
+    processor = _make_processor(track_downscale=1, track_stride=2, sam_run_gap=4, batch_size=3)
+    out = _run(processor, _frames(10))
+    assert [f.raw_frame_idx for f in out] == list(range(10))
+    # Only every other frame is tracked.
+    assert processor.tracker.frame_idx == 5
+    for idx, frame in enumerate(out):
+        # Strided frames reuse the mask of the preceding tracked frame.
+        expected_track_ordinal = idx // 2 + 1
+        assert int(frame.instance[0, 0]) == expected_track_ordinal
+
+
+def test_downscale_tracks_small_and_outputs_full_resolution():
+    processor = _make_processor(track_downscale=2, track_stride=1, sam_run_gap=4, batch_size=1)
+    out = _run(processor, _frames(4, size=(16, 24)))
+    assert all(size == (8, 12) for size in processor.tracker.tracked_sizes)
+    assert all(frame.instance.shape == (16, 24) for frame in out)
+    assert all(frame.mask.shape == (16, 24) for frame in out)
+
+
+def test_batched_stride_preserves_order_and_batches():
+    processor = _make_processor(track_downscale=2, track_stride=2, sam_run_gap=8, batch_size=2)
+    out = _run(processor, _frames(16))
+    assert [f.raw_frame_idx for f in out] == list(range(16))
+    assert processor.tracker.frame_idx == 8
+    assert len(processor.tracker.encoded_batches) > 0
+    for idx, frame in enumerate(out):
+        assert int(frame.instance[0, 0]) == idx // 2 + 1

--- a/vipe/config/__init__.py
+++ b/vipe/config/__init__.py
@@ -3,7 +3,7 @@
 
 from vipe.config.base_schema import BaseConfigSchema, Field, config_to_primitive
 from vipe.config.parse import parse_typed_config, parse_untyped_config, register_config_resolvers, validate_typed_config
-from vipe.config.pipeline import DefaultPipelineConfig, PanoramaPipelineConfig, PipelineConfig
+from vipe.config.pipeline import DefaultPipelineConfig, PanoramaPipelineConfig, PipelineConfig, PoseOnlyPipelineConfig
 from vipe.config.slam import BAConfig, SLAMConfig, SparseTracksConfig
 from vipe.config.streams import FrameDirStreamListConfig, RawMP4StreamListConfig, StreamsConfig
 from vipe.config.vipe import ViPEConfig
@@ -16,6 +16,7 @@ __all__ = [
     "FrameDirStreamListConfig",
     "PanoramaPipelineConfig",
     "PipelineConfig",
+    "PoseOnlyPipelineConfig",
     "RawMP4StreamListConfig",
     "SLAMConfig",
     "SparseTracksConfig",

--- a/vipe/config/pipeline.py
+++ b/vipe/config/pipeline.py
@@ -27,6 +27,18 @@ class InstanceInitConfig(BaseConfigSchema):
     add_sky: bool = Field(
         description="Add a sky mask to the instance segmentation output when the detector supports it."
     )
+    track_downscale: int = Field(
+        default=1,
+        ge=1,
+        description="Downscale factor applied to frames before instance tracking. Values above 1 speed up "
+        "tracking considerably; masks are upsampled back to full resolution.",
+    )
+    track_stride: int = Field(
+        default=1,
+        ge=1,
+        description="Track instances only every N-th frame and reuse the previous mask in between. "
+        "Values above 1 speed up tracking at the cost of slightly stale masks on in-between frames.",
+    )
 
 
 class DefaultInitConfig(BaseConfigSchema):
@@ -124,6 +136,27 @@ class DefaultPipelineConfig(BaseConfigSchema):
         return self
 
 
+class PoseOnlyPipelineConfig(BaseConfigSchema):
+    """Fast pose-only pipeline: per-frame camera poses and intrinsics without dense depth."""
+
+    instance: Literal["vipe.pipeline.pose_only.PoseOnlyAnnotationPipeline"] = Field(
+        description="Implementation class for the pose-only annotation pipeline."
+    )
+    init: DefaultInitConfig = Field(description="Initial camera and instance-mask setup.")
+    slam: SLAMConfig = Field(description="SLAM and bundle-adjustment configuration.")
+    output: OutputConfig = Field(description="Output artifact configuration (visualization options are ignored).")
+
+    @model_validator(mode="after")
+    def normalize_fused_ba(self) -> PoseOnlyPipelineConfig:
+        # Same layout as the default monocular pipeline: always single-view; the fused
+        # kernel additionally needs a pinhole camera model.
+        self.slam.ba.fused = self.slam.resolve_fused(
+            single_view=True,
+            pinhole=self.init.camera_type == "pinhole",
+        )
+        return self
+
+
 class PanoramaPipelineConfig(BaseConfigSchema):
     """Annotation pipeline for 360-degree panorama videos."""
 
@@ -149,4 +182,6 @@ class PanoramaPipelineConfig(BaseConfigSchema):
         return self
 
 
-PipelineConfig = Annotated[DefaultPipelineConfig | PanoramaPipelineConfig, Field(discriminator="instance")]
+PipelineConfig = Annotated[
+    DefaultPipelineConfig | PoseOnlyPipelineConfig | PanoramaPipelineConfig, Field(discriminator="instance")
+]

--- a/vipe/config/pipeline.py
+++ b/vipe/config/pipeline.py
@@ -10,12 +10,16 @@ from pydantic import model_validator
 from vipe.config.base_schema import BaseConfigSchema, Field
 from vipe.config.slam import SLAMConfig
 
-FrameAttributeName = Literal["rgb", "instance", "depth", "pcd", "rectified"]
+FrameAttributeName = Literal["rgb", "instance", "mask", "depth", "pcd", "rectified", "empty"]
 
 
 class InstanceInitConfig(BaseConfigSchema):
     """Object and sky-mask initialization used by the segmentation stage."""
 
+    mode: Literal["text", "motion"] = Field(
+        default="text",
+        description="Use text-prompted segmentation or motion-driven dynamic-mask estimation.",
+    )
     kf_gap_sec: float = Field(
         gt=0.0,
         description="Minimum time gap, in seconds, between keyframes used to initialize instance segmentation.",
@@ -38,6 +42,27 @@ class InstanceInitConfig(BaseConfigSchema):
         ge=1,
         description="Track instances only every N-th frame and reuse the previous mask in between. "
         "Values above 1 speed up tracking at the cost of slightly stale masks on in-between frames.",
+    )
+    sam_points_per_side: int = Field(
+        default=16,
+        ge=1,
+        description="SAM grid density used by motion-driven dynamic-mask initialization.",
+    )
+    keep_motion_ratio: float = Field(
+        default=0.15,
+        gt=0.0,
+        le=1.0,
+        description="Fraction of high-motion regions kept for motion-driven mask initialization.",
+    )
+    flow_alpha: float = Field(
+        default=0.5,
+        ge=0.0,
+        description="Forward-flow weight used by motion-driven mask initialization.",
+    )
+    flow_beta: float = Field(
+        default=0.5,
+        ge=0.0,
+        description="Backward-flow weight used by motion-driven mask initialization.",
     )
 
 

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -96,6 +96,9 @@ class DefaultAnnotationPipeline(Pipeline):
         if (depth_align_model := self.post_cfg.depth_align_model) is not None:
             if depth_align_model.startswith("mvd_"):
                 post_processors.append(MultiviewDepthProcessor(slam_output, model=depth_align_model))
+            elif depth_align_model == "video_pi3x_moge2":
+                from vipe.pipeline.processors import VideoPi3XDepthProcessor
+                post_processors.append(VideoPi3XDepthProcessor())
             else:
                 post_processors.append(AdaptiveDepthProcessor(slam_output, view_idx, depth_align_model))
         return ProcessedVideoStream(video_stream, post_processors)

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -187,8 +187,8 @@ class DefaultAnnotationPipeline(Pipeline):
 
                     logger.info(f"Generating TSDF volume for {artifact_path.artifact_name}")
                     volume = o3d.pipelines.integration.ScalableTSDFVolume(
-                        voxel_length=self.out_cfg.get("tsdf_voxel_length", 0.01),
-                        sdf_trunc=self.out_cfg.get("tsdf_sdf_trunc", 0.04),
+                        voxel_length=self.out_cfg.get("tsdf_voxel_length", 0.005),
+                        sdf_trunc=self.out_cfg.get("tsdf_sdf_trunc", 0.02),
                         color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8
                     )
 
@@ -210,7 +210,7 @@ class DefaultAnnotationPipeline(Pipeline):
                         # ------------------------------
 
                         # --- Depth Edge Pruning ---
-                        if self.out_cfg.get("tsdf_apply_edge_pruning", True):
+                        if self.out_cfg.get("tsdf_apply_edge_pruning", False):
                             import cv2
                             grad_x = cv2.Sobel(depth, cv2.CV_64F, 1, 0, ksize=3)
                             grad_y = cv2.Sobel(depth, cv2.CV_64F, 0, 1, ksize=3)
@@ -222,6 +222,8 @@ class DefaultAnnotationPipeline(Pipeline):
 
                         rgb_o3d = o3d.geometry.Image(rgb)
                         depth_o3d = o3d.geometry.Image(depth)
+                        
+                        # Note: depth_scale MUST be 1.0 because ViPE outputs metric depth
                         rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
                             rgb_o3d, depth_o3d, depth_scale=1.0, depth_trunc=10.0, convert_rgb_to_intensity=False
                         )
@@ -235,6 +237,11 @@ class DefaultAnnotationPipeline(Pipeline):
 
                         volume.integrate(rgbd, intrinsic, w2c)
 
+                        # --- Explicit Memory Management ---
+                        # Force Python to release these arrays immediately to prevent OOM on long videos
+                        del rgb, depth, rgb_o3d, depth_o3d, rgbd, intrinsic, c2w, w2c
+                        # ----------------------------------
+
                     tsdf_mesh_path = artifact_path.meta_info_path.parent / f"{artifact_path.artifact_name}_tsdf.ply"
                     pcd = volume.extract_point_cloud()
 
@@ -245,6 +252,15 @@ class DefaultAnnotationPipeline(Pipeline):
                         cl, ind = pcd.remove_statistical_outlier(nb_neighbors=nb_neighbors, std_ratio=std_ratio)
                         pcd = pcd.select_by_index(ind)
                     # -----------------------------------------
+
+                    # --- Coordinate System Flip ---
+                    # ViPE/Open3D use OpenCV format (Y-down). If the backend expects OpenGL (Y-up), we flip X by 180 degrees.
+                    if self.out_cfg.get("tsdf_flip_x_axis", False):
+                        logger.info("Flipping TSDF point cloud 180 degrees around X-axis for OpenGL compatibility")
+                        # 180 degree rotation around X-axis: [1, 0, 0], [0, -1, 0], [0, 0, -1]
+                        R_x_180 = np.array([[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]])
+                        pcd.rotate(R_x_180, center=(0, 0, 0))
+                    # ------------------------------
 
                     o3d.io.write_point_cloud(str(tsdf_mesh_path), pcd)
                     logger.info(f"Saved TSDF point cloud to {tsdf_mesh_path}")

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -187,8 +187,8 @@ class DefaultAnnotationPipeline(Pipeline):
 
                     logger.info(f"Generating TSDF volume for {artifact_path.artifact_name}")
                     volume = o3d.pipelines.integration.ScalableTSDFVolume(
-                        voxel_length=0.01,
-                        sdf_trunc=0.04,
+                        voxel_length=self.out_cfg.get("tsdf_voxel_length", 0.01),
+                        sdf_trunc=self.out_cfg.get("tsdf_sdf_trunc", 0.04),
                         color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8
                     )
 
@@ -200,21 +200,24 @@ class DefaultAnnotationPipeline(Pipeline):
                         depth = frame_data.metric_depth.cpu().numpy()
 
                         # --- Dynamic Object Masking ---
-                        # Check if ViPE generated a mask for moving objects
-                        if hasattr(frame_data, 'mask') and frame_data.mask is not None:
-                            # Convert mask to numpy (usually 1 for static, 0 for dynamic/ignored)
-                            valid_mask = frame_data.mask.cpu().numpy().astype(bool)
-                            # Force dynamic pixels to 0.0 so Open3D's TSDF completely ignores them
-                            depth[~valid_mask] = 0.0
+                        if self.out_cfg.get("tsdf_apply_dynamic_mask", True):
+                            # Check if ViPE generated a mask for moving objects
+                            if hasattr(frame_data, 'mask') and frame_data.mask is not None:
+                                # Convert mask to numpy (usually 1 for static, 0 for dynamic/ignored)
+                                valid_mask = frame_data.mask.cpu().numpy().astype(bool)
+                                # Force dynamic pixels to 0.0 so Open3D's TSDF completely ignores them
+                                depth[~valid_mask] = 0.0
                         # ------------------------------
 
                         # --- Depth Edge Pruning ---
-                        import cv2
-                        grad_x = cv2.Sobel(depth, cv2.CV_64F, 1, 0, ksize=3)
-                        grad_y = cv2.Sobel(depth, cv2.CV_64F, 0, 1, ksize=3)
-                        grad_mag = np.sqrt(grad_x**2 + grad_y**2)
-                        edge_mask = grad_mag > 0.5  
-                        depth[edge_mask] = 0.0
+                        if self.out_cfg.get("tsdf_apply_edge_pruning", True):
+                            import cv2
+                            grad_x = cv2.Sobel(depth, cv2.CV_64F, 1, 0, ksize=3)
+                            grad_y = cv2.Sobel(depth, cv2.CV_64F, 0, 1, ksize=3)
+                            grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+                            threshold = self.out_cfg.get("tsdf_edge_pruning_threshold", 0.5)
+                            edge_mask = grad_mag > threshold  
+                            depth[edge_mask] = 0.0
                         # --------------------------
 
                         rgb_o3d = o3d.geometry.Image(rgb)
@@ -236,11 +239,14 @@ class DefaultAnnotationPipeline(Pipeline):
                     pcd = volume.extract_point_cloud()
 
                     # --- Statistical Outlier Removal (SOR) ---
-                    cl, ind = pcd.remove_statistical_outlier(nb_neighbors=50, std_ratio=2.0)
-                    pcd_clean = pcd.select_by_index(ind)
+                    if self.out_cfg.get("tsdf_apply_sor", True):
+                        nb_neighbors = self.out_cfg.get("tsdf_sor_nb_neighbors", 50)
+                        std_ratio = self.out_cfg.get("tsdf_sor_std_ratio", 2.0)
+                        cl, ind = pcd.remove_statistical_outlier(nb_neighbors=nb_neighbors, std_ratio=std_ratio)
+                        pcd = pcd.select_by_index(ind)
                     # -----------------------------------------
 
-                    o3d.io.write_point_cloud(str(tsdf_mesh_path), pcd_clean)
+                    o3d.io.write_point_cloud(str(tsdf_mesh_path), pcd)
                     logger.info(f"Saved TSDF point cloud to {tsdf_mesh_path}")
                 except ImportError:
                     logger.error("Open3D is not installed. Please install open3d to generate TSDF ply.")

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -229,14 +229,14 @@ class DefaultAnnotationPipeline(Pipeline):
                         depth_o3d = o3d.geometry.Image(depth)
                         
                         # --- Dynamic Depth Truncation ---
-                        # If "auto", use Median + 3*MAD to robustly bound the scene and drop distant outliers (like sky/windows)
+                        # If "auto", use robust IQR (Interquartile Range) to drop distant sky/noise while preserving continuous horizons.
                         raw_trunc = self.out_cfg.get("tsdf_depth_trunc", "auto")
                         if str(raw_trunc).lower() == "auto":
                             valid_depths = depth[depth > 0]
                             if len(valid_depths) > 0:
-                                median_depth = float(np.median(valid_depths))
-                                mad = float(np.median(np.abs(valid_depths - median_depth)))
-                                depth_trunc_val = median_depth + (3.0 * mad)
+                                q75, q25 = np.percentile(valid_depths, [75, 25])
+                                iqr = q75 - q25
+                                depth_trunc_val = float(q75 + (1.5 * iqr))
                             else:
                                 depth_trunc_val = 10.0 # Fallback
                         else:

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -199,6 +199,15 @@ class DefaultAnnotationPipeline(Pipeline):
                         rgb = (frame_data.rgb.cpu().numpy() * 255).astype(np.uint8)
                         depth = frame_data.metric_depth.cpu().numpy()
 
+                        # --- Dynamic Object Masking ---
+                        # Check if ViPE generated a mask for moving objects
+                        if hasattr(frame_data, 'mask') and frame_data.mask is not None:
+                            # Convert mask to numpy (usually 1 for static, 0 for dynamic/ignored)
+                            valid_mask = frame_data.mask.cpu().numpy().astype(bool)
+                            # Force dynamic pixels to 0.0 so Open3D's TSDF completely ignores them
+                            depth[~valid_mask] = 0.0
+                        # ------------------------------
+
                         rgb_o3d = o3d.geometry.Image(rgb)
                         depth_o3d = o3d.geometry.Image(depth)
                         rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -229,12 +229,14 @@ class DefaultAnnotationPipeline(Pipeline):
                         depth_o3d = o3d.geometry.Image(depth)
                         
                         # --- Dynamic Depth Truncation ---
-                        # If "auto", dynamically calculate the 95th percentile to cut off noisy distant background
+                        # If "auto", use Median + 3*MAD to robustly bound the scene and drop distant outliers (like sky/windows)
                         raw_trunc = self.out_cfg.get("tsdf_depth_trunc", "auto")
                         if str(raw_trunc).lower() == "auto":
                             valid_depths = depth[depth > 0]
                             if len(valid_depths) > 0:
-                                depth_trunc_val = float(np.percentile(valid_depths, 95))
+                                median_depth = float(np.median(valid_depths))
+                                mad = float(np.median(np.abs(valid_depths - median_depth)))
+                                depth_trunc_val = median_depth + (3.0 * mad)
                             else:
                                 depth_trunc_val = 10.0 # Fallback
                         else:

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -229,8 +229,9 @@ class DefaultAnnotationPipeline(Pipeline):
                         depth_o3d = o3d.geometry.Image(depth)
                         
                         # Note: depth_scale MUST be 1.0 because ViPE outputs metric depth
+                        depth_trunc_val = self.out_cfg.get("tsdf_depth_trunc", 10.0)
                         rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
-                            rgb_o3d, depth_o3d, depth_scale=1.0, depth_trunc=10.0, convert_rgb_to_intensity=False
+                            rgb_o3d, depth_o3d, depth_scale=1.0, depth_trunc=depth_trunc_val, convert_rgb_to_intensity=False
                         )
 
                         fx, fy, cx, cy = frame_data.intrinsics.cpu().numpy()

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -75,6 +75,8 @@ class DefaultAnnotationPipeline(Pipeline):
                     self.init_cfg.instance.phrases,
                     add_sky=self.init_cfg.instance.add_sky,
                     sam_run_gap=int(video_stream.fps() * self.init_cfg.instance.kf_gap_sec),
+                    track_downscale=self.init_cfg.instance.get("track_downscale", 1),
+                    track_stride=self.init_cfg.instance.get("track_stride", 1),
                     model_cache=self.model_cache,
                 )
             )

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -37,6 +37,7 @@ from vipe.utils.visualization import save_projection_video
 from . import AnnotationPipelineOutput, Pipeline
 from .processors import (
     AdaptiveDepthProcessor,
+    DynamicMaskProcessor,
     GeoCalibIntrinsicsProcessor,
     MultiviewDepthProcessor,
     TrackAnythingProcessor,
@@ -70,16 +71,28 @@ class DefaultAnnotationPipeline(Pipeline):
             GeoCalibIntrinsicsProcessor(video_stream, camera_type=self.camera_type, model_cache=self.model_cache)
         )
         if self.init_cfg.instance is not None:
-            init_processors.append(
-                TrackAnythingProcessor(
-                    self.init_cfg.instance.phrases,
-                    add_sky=self.init_cfg.instance.add_sky,
-                    sam_run_gap=int(video_stream.fps() * self.init_cfg.instance.kf_gap_sec),
-                    track_downscale=self.init_cfg.instance.get("track_downscale", 1),
-                    track_stride=self.init_cfg.instance.get("track_stride", 1),
-                    model_cache=self.model_cache,
+            mode = self.init_cfg.instance.get("mode", "text")
+            if mode == "motion":
+                init_processors.append(
+                    DynamicMaskProcessor(
+                        sam_run_gap=int(video_stream.fps() * self.init_cfg.instance.kf_gap_sec),
+                        sam_points_per_side=self.init_cfg.instance.get("sam_points_per_side", 16),
+                        keep_motion_ratio=self.init_cfg.instance.get("keep_motion_ratio", 0.15),
+                        flow_alpha=self.init_cfg.instance.get("flow_alpha", 0.5),
+                        flow_beta=self.init_cfg.instance.get("flow_beta", 0.5),
+                    )
                 )
-            )
+            else:
+                init_processors.append(
+                    TrackAnythingProcessor(
+                        self.init_cfg.instance.phrases,
+                        add_sky=self.init_cfg.instance.add_sky,
+                        sam_run_gap=int(video_stream.fps() * self.init_cfg.instance.kf_gap_sec),
+                        track_downscale=self.init_cfg.instance.get("track_downscale", 1),
+                        track_stride=self.init_cfg.instance.get("track_stride", 1),
+                        model_cache=self.model_cache,
+                    )
+                )
         return ProcessedVideoStream(video_stream, init_processors)
 
     def _add_post_processors(

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -180,6 +180,47 @@ class DefaultAnnotationPipeline(Pipeline):
                 logger.info(f"Saving SLAM map to {artifact_path.slam_map_path}")
                 slam_output.slam_map.save(artifact_path.slam_map_path)
 
+            if self.out_cfg.get("save_tsdf_ply", False):
+                try:
+                    import open3d as o3d
+                    import numpy as np
+
+                    logger.info(f"Generating TSDF volume for {artifact_path.artifact_name}")
+                    volume = o3d.pipelines.integration.ScalableTSDFVolume(
+                        voxel_length=0.01,
+                        sdf_trunc=0.04,
+                        color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8
+                    )
+
+                    for frame_idx, frame_data in enumerate(output_stream):
+                        if frame_data.pose is None or frame_data.metric_depth is None or frame_data.intrinsics is None:
+                            continue
+
+                        rgb = (frame_data.rgb.cpu().numpy() * 255).astype(np.uint8)
+                        depth = frame_data.metric_depth.cpu().numpy()
+
+                        rgb_o3d = o3d.geometry.Image(rgb)
+                        depth_o3d = o3d.geometry.Image(depth)
+                        rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
+                            rgb_o3d, depth_o3d, depth_scale=1.0, depth_trunc=10.0, convert_rgb_to_intensity=False
+                        )
+
+                        fx, fy, cx, cy = frame_data.intrinsics.cpu().numpy()
+                        h, w = rgb.shape[:2]
+                        intrinsic = o3d.camera.PinholeCameraIntrinsic(w, h, fx, fy, cx, cy)
+
+                        c2w = frame_data.pose.matrix().cpu().numpy()
+                        w2c = np.linalg.inv(c2w)
+
+                        volume.integrate(rgbd, intrinsic, w2c)
+
+                    tsdf_mesh_path = artifact_path.meta_info_path.parent / f"{artifact_path.artifact_name}_tsdf.ply"
+                    pcd = volume.extract_point_cloud()
+                    o3d.io.write_point_cloud(str(tsdf_mesh_path), pcd)
+                    logger.info(f"Saved TSDF point cloud to {tsdf_mesh_path}")
+                except ImportError:
+                    logger.error("Open3D is not installed. Please install open3d to generate TSDF ply.")
+
         if self.return_output_streams:
             annotate_output.output_streams = output_streams
 

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -228,8 +228,20 @@ class DefaultAnnotationPipeline(Pipeline):
                         rgb_o3d = o3d.geometry.Image(rgb)
                         depth_o3d = o3d.geometry.Image(depth)
                         
+                        # --- Dynamic Depth Truncation ---
+                        # If "auto", dynamically calculate the 95th percentile to cut off noisy distant background
+                        raw_trunc = self.out_cfg.get("tsdf_depth_trunc", "auto")
+                        if str(raw_trunc).lower() == "auto":
+                            valid_depths = depth[depth > 0]
+                            if len(valid_depths) > 0:
+                                depth_trunc_val = float(np.percentile(valid_depths, 95))
+                            else:
+                                depth_trunc_val = 10.0 # Fallback
+                        else:
+                            depth_trunc_val = float(raw_trunc)
+                        # --------------------------------
+
                         # Note: depth_scale MUST be 1.0 because ViPE outputs metric depth
-                        depth_trunc_val = self.out_cfg.get("tsdf_depth_trunc", 10.0)
                         rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
                             rgb_o3d, depth_o3d, depth_scale=1.0, depth_trunc=depth_trunc_val, convert_rgb_to_intensity=False
                         )

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -208,6 +208,15 @@ class DefaultAnnotationPipeline(Pipeline):
                             depth[~valid_mask] = 0.0
                         # ------------------------------
 
+                        # --- Depth Edge Pruning ---
+                        import cv2
+                        grad_x = cv2.Sobel(depth, cv2.CV_64F, 1, 0, ksize=3)
+                        grad_y = cv2.Sobel(depth, cv2.CV_64F, 0, 1, ksize=3)
+                        grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+                        edge_mask = grad_mag > 0.5  
+                        depth[edge_mask] = 0.0
+                        # --------------------------
+
                         rgb_o3d = o3d.geometry.Image(rgb)
                         depth_o3d = o3d.geometry.Image(depth)
                         rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
@@ -225,7 +234,13 @@ class DefaultAnnotationPipeline(Pipeline):
 
                     tsdf_mesh_path = artifact_path.meta_info_path.parent / f"{artifact_path.artifact_name}_tsdf.ply"
                     pcd = volume.extract_point_cloud()
-                    o3d.io.write_point_cloud(str(tsdf_mesh_path), pcd)
+
+                    # --- Statistical Outlier Removal (SOR) ---
+                    cl, ind = pcd.remove_statistical_outlier(nb_neighbors=50, std_ratio=2.0)
+                    pcd_clean = pcd.select_by_index(ind)
+                    # -----------------------------------------
+
+                    o3d.io.write_point_cloud(str(tsdf_mesh_path), pcd_clean)
                     logger.info(f"Saved TSDF point cloud to {tsdf_mesh_path}")
                 except ImportError:
                     logger.error("Open3D is not installed. Please install open3d to generate TSDF ply.")

--- a/vipe/pipeline/default.py
+++ b/vipe/pipeline/default.py
@@ -209,16 +209,21 @@ class DefaultAnnotationPipeline(Pipeline):
                                 depth[~valid_mask] = 0.0
                         # ------------------------------
 
-                        # --- Depth Edge Pruning ---
+                        # --- Relative Depth Edge Pruning ---
                         if self.out_cfg.get("tsdf_apply_edge_pruning", False):
                             import cv2
                             grad_x = cv2.Sobel(depth, cv2.CV_64F, 1, 0, ksize=3)
                             grad_y = cv2.Sobel(depth, cv2.CV_64F, 0, 1, ksize=3)
                             grad_mag = np.sqrt(grad_x**2 + grad_y**2)
-                            threshold = self.out_cfg.get("tsdf_edge_pruning_threshold", 0.5)
-                            edge_mask = grad_mag > threshold  
+                            
+                            # Calculate RELATIVE gradient (gradient divided by absolute depth)
+                            # Adding 1e-6 prevents division by zero
+                            relative_grad = grad_mag / (depth + 1e-6)
+                            
+                            prune_thresh = self.out_cfg.get("tsdf_pruning_threshold", 0.10)
+                            edge_mask = relative_grad > prune_thresh  
                             depth[edge_mask] = 0.0
-                        # --------------------------
+                        # -----------------------------------
 
                         rgb_o3d = o3d.geometry.Image(rgb)
                         depth_o3d = o3d.geometry.Image(depth)

--- a/vipe/pipeline/pose_only.py
+++ b/vipe/pipeline/pose_only.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+import pickle
+
+import numpy as np
+import torch
+
+from omegaconf import DictConfig, OmegaConf
+
+from vipe.slam.system import SLAMOutput, SLAMSystem
+from vipe.streams.base import MultiviewVideoList, VideoStream
+from vipe.utils import io
+from vipe.utils.cameras import CameraType
+
+from . import AnnotationPipelineOutput, Pipeline
+from .default import DefaultAnnotationPipeline
+
+logger = logging.getLogger(__name__)
+
+
+class PoseOnlyAnnotationPipeline(DefaultAnnotationPipeline):
+    """Fast pipeline that estimates per-frame camera poses and intrinsics only.
+
+    Compared to the default pipeline this skips all per-frame dense depth work:
+    the depth-alignment post-processing pass and the depth/mask artifact dump.
+    SLAM (including its keyframe-only metric depth prior and dynamic-object
+    masking) is unchanged, so the recovered trajectory is identical to the one
+    produced by the default pipeline.
+    """
+
+    def __init__(self, init: DictConfig, slam: DictConfig, output: DictConfig) -> None:
+        super().__init__(init, slam, post=OmegaConf.create({"depth_align_model": None}), output=output)
+
+    def _save_pose_artifacts(
+        self, artifact_path: io.ArtifactPath, view_idx: int, slam_output: SLAMOutput, n_frames: int
+    ) -> None:
+        # Written directly from the SLAM output so no extra pass over the
+        # video frames is needed. Formats match io.save_artifacts.
+        trajectory = slam_output.get_view_trajectory(view_idx)
+        pose_data = trajectory.matrix().cpu().numpy()
+        pose_inds = np.arange(n_frames)
+        artifact_path.pose_path.parent.mkdir(exist_ok=True, parents=True)
+        np.savez(artifact_path.pose_path, data=pose_data, inds=pose_inds)
+
+        intrinsics = slam_output.intrinsics[view_idx].cpu().numpy()
+        intrinsics_data = np.repeat(intrinsics[None], n_frames, axis=0)
+        artifact_path.intrinsics_path.parent.mkdir(exist_ok=True, parents=True)
+        np.savez(artifact_path.intrinsics_path, data=intrinsics_data, inds=pose_inds)
+
+        with artifact_path.camera_type_path.open("w") as f:
+            for frame_idx in range(n_frames):
+                f.write(f"{frame_idx}: {self.camera_type.name}\n")
+
+        artifact_path.meta_info_path.parent.mkdir(exist_ok=True, parents=True)
+        with artifact_path.meta_info_path.open("wb") as f:
+            pickle.dump({"ba_residual": slam_output.ba_residual}, f)
+
+    def run(self, video_data: VideoStream | MultiviewVideoList) -> AnnotationPipelineOutput:
+        if isinstance(video_data, MultiviewVideoList):
+            video_streams = [video_data[view_idx] for view_idx in range(len(video_data))]
+            slam_rig = video_data.rig()
+        else:
+            assert isinstance(video_data, VideoStream)
+            video_streams = [video_data]
+            slam_rig = None
+
+        artifact_paths = [io.ArtifactPath(self.out_path, video_stream.name()) for video_stream in video_streams]
+
+        annotate_output = AnnotationPipelineOutput()
+
+        if all([self.should_filter(video_stream.name()) for video_stream in video_streams]):
+            logger.info(f"{video_data.name()} has been proccessed already, skip it!!")
+            return annotate_output
+
+        slam_streams: list[VideoStream] = [
+            self._add_init_processors(video_stream).cache(
+                "process",
+                online=True,
+                async_prefetch=self.init_cfg.async_prefetch,
+                prefetch_queue_size=self.init_cfg.prefetch_queue_size,
+            )
+            for video_stream in video_streams
+        ]
+
+        slam_pipeline = SLAMSystem(device=torch.device("cuda"), config=self.slam_cfg, model_cache=self.model_cache)
+        slam_output = slam_pipeline.run(slam_streams, rig=slam_rig, camera_type=self.camera_type)
+
+        if self.return_payload:
+            annotate_output.payload = slam_output
+            return annotate_output
+
+        for view_idx, (slam_stream, artifact_path) in enumerate(zip(slam_streams, artifact_paths)):
+            if self.out_cfg.save_artifacts:
+                logger.info(f"Saving pose artifacts to {artifact_path.pose_path}")
+                self._save_pose_artifacts(artifact_path, view_idx, slam_output, len(slam_stream))
+
+            if self.out_cfg.save_slam_map and slam_output.slam_map is not None:
+                logger.info(f"Saving SLAM map to {artifact_path.slam_map_path}")
+                slam_output.slam_map.save(artifact_path.slam_map_path)
+
+        if self.return_output_streams:
+            annotate_output.output_streams = [
+                self._add_post_processors(view_idx, slam_stream, slam_output)
+                for view_idx, slam_stream in enumerate(slam_streams)
+            ]
+
+        return annotate_output

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -27,6 +27,8 @@ from vipe.priors.depth import DepthEstimationInput, make_depth_model
 from vipe.priors.depth.alignment import align_inv_depth_to_depth
 from vipe.priors.depth.priorda import PriorDAModel
 from vipe.priors.depth.videodepthanything import VideoDepthAnythingDepthModel
+from vipe.priors.dynamic_mask import DynamicMaskPipeline
+from vipe.priors.flow import SeaRaftModel
 from vipe.priors.geocalib import GeoCalib
 from vipe.priors.track_anything import TrackAnythingPipeline
 from vipe.slam.interface import SLAMOutput
@@ -247,6 +249,114 @@ class TrackAnythingProcessor(StreamProcessor):
             yield self._process_frame(frame_idx, frame, track_frame)
 
         yield from flush_pending()
+
+
+class DynamicMaskProcessor(StreamProcessor):
+    """Two-pass processor that auto-selects dynamic instances by optical-flow
+    motion score (no text prompt required).
+
+    Pass 0: cache RGB frames + run TrackAnything in auto-seg mode to get
+    consistent class-agnostic instance ids across frames.
+    Pass 1 (after the dynamic-mask pipeline has been resolved): emit each
+    cached frame with `frame.instance` / `frame.instance_phrases` set to the
+    auto-seg result, and `frame.mask` set to the binary "valid pixel" mask
+    (True for static / sky pixels, False over instances scored as dynamic).
+    """
+
+    n_passes_required = 2
+
+    def __init__(
+        self,
+        sam_run_gap: int = 30,
+        sam_points_per_side: int = 30,
+        mask_expand: int = 5,
+        flow_iters: int | None = None,
+        flow_alpha: float = 0.5,
+        flow_beta: float = 0.5,
+        keep_motion_ratio: float = 0.25,
+        min_area_ratio: float = 1e-4,
+        filter_time_thres: float = 1e-4,
+        ransac_threshold: float = 0.01,
+    ) -> None:
+        self.mask_expand = mask_expand
+        self.sam_run_gap = sam_run_gap
+        self.sam_points_per_side = sam_points_per_side
+        self.flow_iters = flow_iters
+        self.flow_alpha = flow_alpha
+        self.flow_beta = flow_beta
+        self.keep_motion_ratio = keep_motion_ratio
+        self.min_area_ratio = min_area_ratio
+        self.filter_time_thres = filter_time_thres
+        self.ransac_threshold = ransac_threshold
+
+        self._instances: list[np.ndarray] | None = None
+        self._instance_phrases: dict[int, str] | None = None
+        self._dynamic_masks: list[torch.Tensor] | None = None
+        self._cached_frames: list[VideoFrame] | None = None
+
+    def update_attributes(self, previous_attributes: set[FrameAttribute]) -> set[FrameAttribute]:
+        return previous_attributes | {FrameAttribute.INSTANCE, FrameAttribute.MASK}
+
+    def update_iterator(self, previous_iterator: Iterator[VideoFrame], pass_idx: int) -> Iterator[VideoFrame]:
+        if pass_idx == 0:
+            tracker = TrackAnythingPipeline(
+                mask_phrases=None,
+                sam_points_per_side=self.sam_points_per_side,
+                sam_run_gap=self.sam_run_gap,
+            )
+            cached_frames: list[VideoFrame] = []
+            instance_maps: list[np.ndarray] = []
+            instance_phrases: dict[int, str] = {}
+
+            for frame in previous_iterator:
+                inst, phrases = tracker.track(frame)
+                instance_maps.append(inst.detach().cpu().numpy().astype(np.int32))
+                instance_phrases.update({int(k): v for k, v in phrases.items()})
+                cached_frames.append(frame)
+                yield frame
+
+            S = len(cached_frames)
+            if S < 2:
+                H, W = cached_frames[0].rgb.shape[:2] if S == 1 else (1, 1)
+                self._dynamic_masks = [torch.zeros((H, W), dtype=torch.bool) for _ in range(S)]
+            else:
+                rgb_tensor = torch.stack(
+                    [f.rgb.permute(2, 0, 1).float() for f in cached_frames], dim=0
+                )
+                instances_tensor = torch.from_numpy(np.stack(instance_maps, axis=0))
+                flow_model = SeaRaftModel(iters=self.flow_iters)
+                dyn = DynamicMaskPipeline(
+                    flow_model=flow_model,
+                    flow_alpha=self.flow_alpha,
+                    flow_beta=self.flow_beta,
+                    ransac_threshold=self.ransac_threshold,
+                    keep_motion_ratio=self.keep_motion_ratio,
+                    min_area_ratio=self.min_area_ratio,
+                    filter_time_thres=self.filter_time_thres,
+                )
+                out = dyn.compute(rgb_tensor, instances_tensor)
+                logger.info(
+                    "DynamicMaskProcessor: motion scores=%s, selected=%s",
+                    out.instance_motion_scores,
+                    out.selected_instances,
+                )
+                self._dynamic_masks = [out.masks[i] for i in range(S)]
+
+            self._instances = instance_maps
+            self._instance_phrases = instance_phrases
+            self._cached_frames = cached_frames
+            return
+
+        assert self._dynamic_masks is not None and self._instances is not None
+        cached_frames = self._cached_frames or []
+        for i, frame in enumerate(cached_frames):
+            inst = torch.from_numpy(self._instances[i]).to(frame.rgb.device)
+            frame.instance = inst.to(torch.uint8) if int(inst.max().item()) < 256 else inst
+            frame.instance_phrases = dict(self._instance_phrases or {})
+
+            dyn = self._dynamic_masks[i].to(frame.rgb.device)
+            frame.mask = erode(~dyn, self.mask_expand)
+            yield frame
 
 
 class AdaptiveDepthProcessor(StreamProcessor):

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -292,10 +292,17 @@ class DynamicMaskProcessor(StreamProcessor):
         self._instances: list[np.ndarray] | None = None
         self._instance_phrases: dict[int, str] | None = None
         self._dynamic_masks: list[torch.Tensor] | None = None
+        self._optical_flows: list[torch.Tensor] | None = None
+        self._flow_consistency: list[torch.Tensor] | None = None
         self._cached_frames: list[VideoFrame] | None = None
 
     def update_attributes(self, previous_attributes: set[FrameAttribute]) -> set[FrameAttribute]:
-        return previous_attributes | {FrameAttribute.INSTANCE, FrameAttribute.MASK}
+        return previous_attributes | {
+            FrameAttribute.INSTANCE,
+            FrameAttribute.MASK,
+            FrameAttribute.OPTICAL_FLOW,
+            FrameAttribute.FLOW_CONSISTENCY,
+        }
 
     def update_iterator(self, previous_iterator: Iterator[VideoFrame], pass_idx: int) -> Iterator[VideoFrame]:
         if pass_idx == 0:
@@ -319,6 +326,8 @@ class DynamicMaskProcessor(StreamProcessor):
             if S < 2:
                 H, W = cached_frames[0].rgb.shape[:2] if S == 1 else (1, 1)
                 self._dynamic_masks = [torch.zeros((H, W), dtype=torch.bool) for _ in range(S)]
+                self._optical_flows = [torch.zeros((H, W, 4), dtype=torch.float32) for _ in range(S)]
+                self._flow_consistency = [torch.ones((H, W, 2), dtype=torch.bool) for _ in range(S)]
             else:
                 rgb_tensor = torch.stack(
                     [f.rgb.permute(2, 0, 1).float() for f in cached_frames], dim=0
@@ -341,13 +350,22 @@ class DynamicMaskProcessor(StreamProcessor):
                     out.selected_instances,
                 )
                 self._dynamic_masks = [out.masks[i] for i in range(S)]
+                self._optical_flows = [out.optical_flow[i] for i in range(S)]
+                self._flow_consistency = [
+                    torch.stack([out.fwd_consistency[i], out.bwd_consistency[i]], dim=-1) for i in range(S)
+                ]
 
             self._instances = instance_maps
             self._instance_phrases = instance_phrases
             self._cached_frames = cached_frames
             return
 
-        assert self._dynamic_masks is not None and self._instances is not None
+        assert (
+            self._dynamic_masks is not None
+            and self._instances is not None
+            and self._optical_flows is not None
+            and self._flow_consistency is not None
+        )
         cached_frames = self._cached_frames or []
         for i, frame in enumerate(cached_frames):
             inst = torch.from_numpy(self._instances[i]).to(frame.rgb.device)
@@ -356,6 +374,8 @@ class DynamicMaskProcessor(StreamProcessor):
 
             dyn = self._dynamic_masks[i].to(frame.rgb.device)
             frame.mask = erode(~dyn, self.mask_expand)
+            frame.optical_flow = self._optical_flows[i].to(frame.rgb.device)
+            frame.flow_consistency = self._flow_consistency[i].to(frame.rgb.device)
             yield frame
 
 

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -623,3 +623,144 @@ class EquirectProjectionProcessor(StreamProcessor):
             instance=new_instance,
             mask=new_mask,
         )
+
+
+class VideoPi3XDepthProcessor(StreamProcessor):
+    """
+    Full-video Pi3X + MoGe-2 depth alignment (SANA-WM Plan A).
+
+    Unlike AdaptiveDepthProcessor (per-frame streaming), this processor:
+      1. Collects ALL frames of the video into memory.
+      2. Runs Pi3X in 16-frame chunks for sequence-consistent relative depth.
+      3. Runs MoGe-2 per-frame for metric scale anchoring.
+      4. Fuses with EMA (momentum=0.99) to produce final metric depth.
+      5. Yields each frame with metric_depth set.
+
+    Env vars required:
+      SANA_WM_PI3X_WEIGHTS  — path to Pi3X weights dir
+      SANA_WM_MOGE2_WEIGHTS — path to MoGe-2 weights dir (or model.pt file)
+    """
+
+    n_passes_required = 1
+    require_cache = True
+
+    def __init__(self, device: str = "cuda", ema_momentum: float = 0.99,
+                 chunk: int = 16, stride: int = 8) -> None:
+        self.device = device
+        self.ema_momentum = ema_momentum
+        self.chunk = chunk
+        self.stride = stride
+        self._pi3x = None
+        self._moge2 = None
+
+    def _lazy_load(self) -> None:
+        import os, pathlib
+        if self._pi3x is not None:
+            return
+        pi3x_w = os.environ.get("SANA_WM_PI3X_WEIGHTS")
+        moge2_w = os.environ.get("SANA_WM_MOGE2_WEIGHTS")
+        if pi3x_w is None or moge2_w is None:
+            raise RuntimeError("Set SANA_WM_PI3X_WEIGHTS and SANA_WM_MOGE2_WEIGHTS before using VideoPi3XDepthProcessor.")
+        from pi3 import Pi3X  # type: ignore
+        self._pi3x = Pi3X.from_pretrained(pi3x_w).to(self.device).eval()
+        from moge.model.v2 import MoGeModel  # type: ignore
+        moge2_path = pathlib.Path(moge2_w)
+        moge2_ckpt = moge2_path / "model.pt" if moge2_path.is_dir() else moge2_path
+        self._moge2 = MoGeModel.from_pretrained(str(moge2_ckpt)).to(self.device).eval()
+
+    def update_attributes(self, previous_attributes: set) -> set:
+        return previous_attributes | {FrameAttribute.METRIC_DEPTH}
+
+    @torch.no_grad()
+    def _run_pi3x(self, frames_t: torch.Tensor) -> np.ndarray:
+        """frames_t: (T, 3, H, W) float32 [0,1] on device. Returns (T, H_orig, W_orig)."""
+        import torch.nn.functional as F_nn
+        T, _, H, W = frames_t.shape
+        H_r = (H // 14) * 14
+        W_r = (W // 14) * 14
+        src = F_nn.interpolate(frames_t, size=(H_r, W_r), mode="bilinear", align_corners=False) if (H_r != H or W_r != W) else frames_t
+
+        accum = np.zeros((T, H_r, W_r), dtype=np.float32)
+        count = np.zeros(T, dtype=np.float32)
+        starts = list(range(0, max(T - self.chunk + 1, 1), self.stride))
+        if not starts or starts[-1] + self.chunk < T:
+            starts.append(max(0, T - self.chunk))
+        for s in starts:
+            e = min(s + self.chunk, T)
+            out = self._pi3x(src[s:e].unsqueeze(0))  # type: ignore
+            d = out["local_points"][0, :e - s, :, :, 2].cpu().numpy()
+            accum[s:e] += d
+            count[s:e] += 1
+        d_r = accum / np.maximum(count[:, None, None], 1.0)
+
+        if H_r != H or W_r != W:
+            d_r = F_nn.interpolate(
+                torch.from_numpy(d_r).unsqueeze(1).to(self.device),
+                size=(H, W), mode="bilinear", align_corners=False
+            ).squeeze(1).cpu().numpy()
+        return d_r  # (T, H, W)
+
+    @torch.no_grad()
+    def _run_moge2(self, frames_t: torch.Tensor, fov_x: float | None) -> np.ndarray:
+        """frames_t: (T, 3, H, W). Returns (T, H, W) metric depth."""
+        results = []
+        for i in range(len(frames_t)):
+            out = self._moge2.infer(frames_t[i:i+1], fov_x=fov_x)  # type: ignore
+            results.append(out["depth"].squeeze(0).cpu().numpy())
+        return np.stack(results, axis=0)  # (T, H, W)
+
+    @staticmethod
+    def _ema_fuse(d_pi3x: np.ndarray, d_moge: np.ndarray, momentum: float) -> np.ndarray:
+        T = len(d_pi3x)
+        scales = np.zeros(T, dtype=np.float32)
+        ema = None
+        for t in range(T):
+            mask = (d_pi3x[t] > 0) & (d_moge[t] > 0)
+            ratio = float(d_moge[t][mask].mean() / (d_pi3x[t][mask].mean() + 1e-8)) if mask.sum() > 10 else 1.0
+            ema = ratio if ema is None else ema * momentum + ratio * (1 - momentum)
+            scales[t] = ema
+        return scales  # (T,)
+
+    def update_iterator(self, previous_iterator: Iterator["VideoFrame"], pass_idx: int) -> Iterator["VideoFrame"]:
+        import math
+        # --- 1. Collect all frames ---
+        frames_cpu, rgb_np, intrinsics_0 = [], [], None
+        for frame in pbar(previous_iterator, desc="Collecting frames for Pi3X"):
+            frames_cpu.append(frame.cpu())
+            rgb_np.append(frame.rgb.cpu().numpy().astype(np.float32))  # (H, W, 3)
+            if intrinsics_0 is None and frame.intrinsics is not None:
+                intrinsics_0 = frame.intrinsics.cpu()
+        T = len(frames_cpu)
+        if T == 0:
+            return
+
+        # --- 2. Load models ---
+        self._lazy_load()
+
+        H, W = rgb_np[0].shape[:2]
+        frames_t = torch.from_numpy(np.stack(rgb_np, 0)).permute(0, 3, 1, 2).to(self.device)  # (T,3,H,W)
+
+        # fov_x from intrinsics
+        fov_x = None
+        if intrinsics_0 is not None:
+            fx = intrinsics_0[0].item()
+            fov_x = math.degrees(2 * math.atan(W / (2 * fx)))
+
+        # --- 3. Pi3X chunked (sequence-consistent relative depth) ---
+        logging.getLogger(__name__).info(f"[VideoPi3X] Running Pi3X on {T} frames ({self.chunk}-frame chunks)...")
+        d_pi3x = self._run_pi3x(frames_t)   # (T, H, W)
+
+        # --- 4. MoGe-2 per-frame (metric scale) ---
+        logging.getLogger(__name__).info(f"[VideoPi3X] Running MoGe-2 on {T} frames...")
+        d_moge = self._run_moge2(frames_t, fov_x)  # (T, H, W)
+
+        # --- 5. EMA scale fusion ---
+        scale = self._ema_fuse(d_pi3x, d_moge, self.ema_momentum)  # (T,)
+        metric = (d_pi3x * scale[:, None, None]).astype(np.float32)  # (T, H, W)
+        logging.getLogger(__name__).info(f"[VideoPi3X] Depth fusion done. Scale range: {scale.min():.3f}~{scale.max():.3f}")
+
+        # --- 6. Yield frames with metric_depth ---
+        for i, frame in enumerate(frames_cpu):
+            frame = frame.cuda()
+            frame.metric_depth = torch.from_numpy(metric[i]).to(self.device)
+            yield frame

--- a/vipe/pipeline/processors.py
+++ b/vipe/pipeline/processors.py
@@ -129,12 +129,18 @@ class TrackAnythingProcessor(StreamProcessor):
         add_sky: bool,
         sam_run_gap: int = 30,
         mask_expand: int = 5,
+        track_downscale: int = 1,
+        track_stride: int = 1,
         model_cache: ModelCache | None = None,
     ) -> None:
         # Defensive copy: prevent mutation of caller's list
         self.mask_phrases = list(mask_phrases)
-        self.sam_run_gap = sam_run_gap
         self.add_sky = add_sky
+        self.track_downscale = max(1, int(track_downscale))
+        self.track_stride = max(1, int(track_stride))
+        # The tracker only sees every track_stride-th frame, so divide the gap
+        # to keep the SAM re-detection cadence constant in wall-clock frames.
+        self.sam_run_gap = max(1, sam_run_gap // self.track_stride)
 
         if self.add_sky:
             self.mask_phrases.append(VideoFrame.SKY_PROMPT)
@@ -147,17 +153,40 @@ class TrackAnythingProcessor(StreamProcessor):
         )
         self.mask_expand = mask_expand
         self.aot_encoder_batch_size = max(1, int(os.environ.get("VIPE_TRACK_ANYTHING_AOT_ENCODER_BATCH_SIZE", "4")))
+        self._last_instance: torch.Tensor | None = None
+        self._last_phrases: dict[int, str] | None = None
+        self._last_mask: torch.Tensor | None = None
 
     def update_attributes(self, previous_attributes: set[FrameAttribute]) -> set[FrameAttribute]:
         return previous_attributes | {FrameAttribute.INSTANCE, FrameAttribute.MASK}
+
+    def _make_track_frame(self, frame: VideoFrame) -> VideoFrame:
+        """Downscaled copy of the frame used for tracking only."""
+        if self.track_downscale == 1:
+            return frame
+        height, width = frame.size()
+        track_size = (height // self.track_downscale, width // self.track_downscale)
+        track_rgb = torch.nn.functional.interpolate(frame.rgb.moveaxis(-1, 0)[None], track_size, mode="area")[
+            0
+        ].moveaxis(0, -1)
+        return VideoFrame(raw_frame_idx=frame.raw_frame_idx, rgb=track_rgb)
 
     def _process_frame(
         self,
         frame_idx: int,
         frame: VideoFrame,
+        track_frame: VideoFrame | None = None,
         aot_img_embs: tuple[torch.Tensor, ...] | None = None,
     ) -> VideoFrame:
-        frame.instance, frame.instance_phrases = self.tracker.track(frame, aot_img_embs=aot_img_embs)
+        if track_frame is None:
+            track_frame = self._make_track_frame(frame)
+        instance, phrases = self.tracker.track(track_frame, aot_img_embs=aot_img_embs)
+        if track_frame is not frame:
+            instance = (
+                torch.nn.functional.interpolate(instance[None, None].float(), frame.size(), mode="nearest")[0, 0]
+                .to(torch.uint8)
+            )
+        frame.instance, frame.instance_phrases = instance, phrases
         self.last_track_frame = frame.raw_frame_idx
 
         frame_instance_mask = frame.instance == 0
@@ -166,40 +195,56 @@ class TrackAnythingProcessor(StreamProcessor):
             frame_instance_mask |= frame.sky_mask
 
         frame.mask = erode(frame_instance_mask, self.mask_expand)
+        self._last_instance = frame.instance
+        self._last_phrases = frame.instance_phrases
+        self._last_mask = frame.mask
+        return frame
+
+    def _copy_last_result(self, frame: VideoFrame) -> VideoFrame:
+        """Reuse the most recent tracking result for an in-between (strided) frame."""
+        assert self._last_instance is not None, "Strided frame encountered before any tracked frame"
+        frame.instance = self._last_instance
+        frame.instance_phrases = self._last_phrases
+        frame.mask = self._last_mask
         return frame
 
     def __call__(self, frame_idx: int, frame: VideoFrame) -> VideoFrame:
+        if frame_idx % self.track_stride != 0 and self._last_instance is not None:
+            return self._copy_last_result(frame)
         return self._process_frame(frame_idx, frame)
 
     def update_iterator(self, previous_iterator: Iterator[VideoFrame], pass_idx: int) -> Iterator[VideoFrame]:
-        if self.aot_encoder_batch_size <= 1:
-            for frame_idx, frame in enumerate(previous_iterator):
-                yield self._process_frame(frame_idx, frame)
-            return
-
-        pending_indices: list[int] = []
-        pending_frames: list[VideoFrame] = []
+        # Tracked frames pending batched AOT encoding, each carrying the
+        # strided frames that follow it (which reuse its result).
+        pending: list[tuple[int, VideoFrame, VideoFrame, list[VideoFrame]]] = []
 
         def flush_pending() -> Iterator[VideoFrame]:
-            nonlocal pending_indices, pending_frames
-            if not pending_frames:
+            if not pending:
                 return
-            embeddings = self.tracker.encode_aot_frames(pending_frames)
-            for pending_idx, pending_frame, aot_img_embs in zip(pending_indices, pending_frames, embeddings):
-                yield self._process_frame(pending_idx, pending_frame, aot_img_embs=aot_img_embs)
-            pending_indices = []
-            pending_frames = []
+            embeddings = self.tracker.encode_aot_frames([track_frame for _, _, track_frame, _ in pending])
+            for (frame_idx, frame, track_frame, skipped), aot_img_embs in zip(pending, embeddings):
+                yield self._process_frame(frame_idx, frame, track_frame, aot_img_embs=aot_img_embs)
+                for skipped_frame in skipped:
+                    yield self._copy_last_result(skipped_frame)
+            pending.clear()
 
         for frame_idx, frame in enumerate(previous_iterator):
-            if self.tracker.should_batch_aot_frame(len(pending_frames)):
-                pending_indices.append(frame_idx)
-                pending_frames.append(frame)
-                if len(pending_frames) >= self.aot_encoder_batch_size:
+            if frame_idx % self.track_stride != 0:
+                if pending:
+                    pending[-1][3].append(frame)
+                else:
+                    yield self._copy_last_result(frame)
+                continue
+
+            track_frame = self._make_track_frame(frame)
+            if self.aot_encoder_batch_size > 1 and self.tracker.should_batch_aot_frame(len(pending)):
+                pending.append((frame_idx, frame, track_frame, []))
+                if len(pending) >= self.aot_encoder_batch_size:
                     yield from flush_pending()
                 continue
 
             yield from flush_pending()
-            yield self._process_frame(frame_idx, frame)
+            yield self._process_frame(frame_idx, frame, track_frame)
 
         yield from flush_pending()
 

--- a/vipe/priors/depth/__init__.py
+++ b/vipe/priors/depth/__init__.py
@@ -42,5 +42,18 @@ def make_depth_model(model: str):
 
         return DepthAnything3Model()
 
+
+    elif model_name == "pi3x_moge2" or (model_name == "pi3x" and model_sub == "moge2"):
+        from .pi3x_moge2 import Pi3XMoGe2DepthModel
+        return Pi3XMoGe2DepthModel()
+
+    elif model_name == "cached":
+        import os
+        from .cached import CachedDepthModel
+        cache_path = os.environ.get("SANA_WM_CACHED_DEPTH_PATH", "")
+        if not cache_path:
+            raise ValueError("cached depth model requires SANA_WM_CACHED_DEPTH_PATH env var")
+        return CachedDepthModel(cache_path=cache_path)
+
     else:
         raise ValueError(f"Unknown depth model: {model}")

--- a/vipe/priors/depth/base.py
+++ b/vipe/priors/depth/base.py
@@ -77,6 +77,7 @@ class DepthEstimationInput:
     prompt_metric_depth: torch.Tensor | None = None
     intrinsics: torch.Tensor | None = None
     camera_type: CameraType = CameraType.PINHOLE
+    frame_idx: int | None = None
 
 
 class DepthEstimationModel(ABC):

--- a/vipe/priors/depth/cached.py
+++ b/vipe/priors/depth/cached.py
@@ -1,0 +1,41 @@
+import logging
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .base import DepthEstimationInput, DepthEstimationModel, DepthEstimationResult, DepthType
+
+log = logging.getLogger(__name__)
+
+
+class CachedDepthModel(DepthEstimationModel):
+    """
+    Pre-computed per-frame metric depths loaded from .npz cache.
+    Feeds Pi3X+MoGe-2 fused depths directly into SLAM BA loop via frame_idx lookup.
+    Cache format: depths (T, H_orig, W_orig) float32 in metres.
+    """
+
+    def __init__(self, cache_path: str):
+        d = np.load(cache_path)
+        self._depths = d["depths"].astype(np.float32)  # (T, H, W)
+        log.info(f"[CachedDepthModel] Loaded {len(self._depths)} frames from {cache_path}")
+
+    @property
+    def depth_type(self) -> DepthType:
+        return DepthType.METRIC_DEPTH
+
+    def estimate(self, src: DepthEstimationInput) -> DepthEstimationResult:
+        idx = src.frame_idx
+        if idx is None or idx < 0 or idx >= len(self._depths):
+            raise ValueError(f"[CachedDepthModel] Invalid frame_idx={idx}, cache has {len(self._depths)} frames")
+
+        depth_np = self._depths[idx]  # (H_orig, W_orig)
+        depth = torch.from_numpy(depth_np).unsqueeze(0).unsqueeze(0)  # (1, 1, H, W)
+
+        target_h, target_w = src.rgb.shape[-3], src.rgb.shape[-2]
+        if depth.shape[-2] != target_h or depth.shape[-1] != target_w:
+            depth = F.interpolate(depth, size=(target_h, target_w), mode="bilinear", align_corners=False)
+
+        # Return (1, H, W) to match VIPE's expected metric_depth shape
+        return DepthEstimationResult(metric_depth=depth.squeeze(0))

--- a/vipe/priors/depth/pi3x_moge2.py
+++ b/vipe/priors/depth/pi3x_moge2.py
@@ -1,0 +1,217 @@
+"""VIPE-compatible depth backend: Pi3X (consistent) + MoGe-2 (metric scale).
+
+Paper App. B.1 protocol:
+  1. Pi3X infers (T,H,W) long-sequence-consistent relative depth.
+  2. MoGe-2 infers (T,H,W) per-frame metric depth.
+  3. EMA-momentum-0.99 closed-form scale fusion (App. B.1) gives per-frame
+     scale s_t that converts Pi3X depth to metric.
+
+Integration: drop into vipe/priors/depth/ and register in vipe/priors/depth/__init__.py
+as make_depth_model("pi3x_moge2") -> Pi3XMoGe2DepthModel().
+
+Install prerequisites:
+  pip install git+https://github.com/yyfz/Pi3.git   # Pi3X code
+  hf download yyfz233/Pi3X --local-dir <weights>    # Pi3X weights
+  pip install git+https://github.com/microsoft/MoGe.git  # MoGe code
+  hf download Ruicheng/moge-2-vitl-normal --local-dir <weights>  # MoGe-2 weights
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import numpy as np
+import torch
+
+from vipe.utils.misc import unpack_optional
+
+from .base import DepthEstimationInput, DepthEstimationModel, DepthEstimationResult, DepthType
+
+
+def _fuse_ema(d_consistent: np.ndarray, d_metric: np.ndarray,
+              momentum: float = 0.99) -> np.ndarray:
+    """Closed-form EMA scale fusion (App. B.1).
+
+    s_t = Σ(w · a · b) / Σ(w · a²),  w = 1/a  (inverse-depth weighting)
+    where a = d_consistent[t], b = d_metric[t].
+    """
+    T = d_consistent.shape[0]
+    scale = np.ones(T, dtype=np.float32)
+    ema_s = None
+    for t in range(T):
+        a = d_consistent[t].flatten().astype(np.float64)
+        b = d_metric[t].flatten().astype(np.float64)
+        valid = (a > 1e-6) & (b > 1e-6) & np.isfinite(a) & np.isfinite(b)
+        if valid.sum() < 16:
+            s_t = ema_s if ema_s is not None else 1.0
+        else:
+            av, bv = a[valid], b[valid]
+            w = 1.0 / np.clip(av, 1e-6, None)
+            s_t = float(np.sum(w * av * bv) / np.sum(w * av * av))
+        ema_s = s_t if ema_s is None else momentum * ema_s + (1 - momentum) * s_t
+        scale[t] = float(ema_s)
+    return scale
+
+
+class Pi3XMoGe2DepthModel(DepthEstimationModel):
+    """Pi3X + MoGe-2 fused depth for SANA-WM (App. B.1).
+
+    Environment variables:
+      SANA_WM_PI3X_WEIGHTS  — path to yyfz233/Pi3X local_dir (required)
+      SANA_WM_MOGE2_WEIGHTS — path to Ruicheng/moge-2-vitl-normal local_dir (required)
+    """
+
+    def __init__(self, device: str = "cuda", ema_momentum: float = 0.99) -> None:
+        super().__init__()
+        self.device = device
+        self.ema_momentum = ema_momentum
+        self._pi3x: Optional[object] = None
+        self._moge2: Optional[object] = None
+        self._video_buffer: list[np.ndarray] = []
+
+    def _lazy_load(self) -> None:
+        if self._pi3x is not None:
+            return
+
+        pi3x_weights = os.environ.get("SANA_WM_PI3X_WEIGHTS")
+        moge2_weights = os.environ.get("SANA_WM_MOGE2_WEIGHTS")
+
+        if pi3x_weights is None or moge2_weights is None:
+            raise RuntimeError(
+                "Set SANA_WM_PI3X_WEIGHTS and SANA_WM_MOGE2_WEIGHTS env vars "
+                "to the local weight directories before using Pi3XMoGe2DepthModel."
+            )
+
+        try:
+            from pi3 import Pi3X  # type: ignore
+            self._pi3x = Pi3X.from_pretrained(pi3x_weights).to(self.device).eval()
+        except ImportError as e:
+            raise RuntimeError(
+                "Pi3X (pip install git+https://github.com/yyfz/Pi3.git) not found."
+            ) from e
+
+        try:
+            from moge.model.v2 import MoGeModel  # type: ignore
+            import pathlib
+            moge2_path = pathlib.Path(moge2_weights)
+            moge2_ckpt = moge2_path / "model.pt" if moge2_path.is_dir() else moge2_path
+            self._moge2 = MoGeModel.from_pretrained(str(moge2_ckpt)).to(self.device).eval()
+        except ImportError as e:
+            raise RuntimeError(
+                "MoGe (pip install git+https://github.com/microsoft/MoGe.git) not found."
+            ) from e
+
+    @property
+    def depth_type(self) -> DepthType:
+        return DepthType.METRIC_DEPTH
+
+    def estimate(self, src: DepthEstimationInput) -> DepthEstimationResult:
+        """Process a single frame (VIPE calls this per-frame during SLAM).
+
+        Pi3X requires the full video context for sequence-consistent depth.
+        We buffer all frames and run Pi3X in batch on the first call after the
+        video is complete (video_frame_list is not None).
+
+        For per-frame SLAM keyframe calls (rgb only), we fall back to MoGe-2
+        metric depth directly (Pi3X sequence context not available yet).
+        """
+        self._lazy_load()
+
+        # Video-sequence mode (post-SLAM depth alignment): process full clip.
+        if src.video_frame_list is not None:
+            return self._estimate_video(src)
+
+        # Per-frame mode (SLAM keyframe): use MoGe-2 only.
+        return self._estimate_single(src)
+
+    @torch.no_grad()
+    def _estimate_single(self, src: DepthEstimationInput) -> DepthEstimationResult:
+        rgb = unpack_optional(src.rgb).to(self.device)
+        if rgb.dim() == 3:
+            rgb = rgb[None]
+            was_unbatched = True
+        else:
+            was_unbatched = False
+        # MoGe-2 inference — rgb is (B, H, W, 3) here
+        inp = rgb.permute(0, 3, 1, 2)  # (B, 3, H, W)
+        fov_x = None
+        if src.intrinsics is not None:
+            fx = src.intrinsics[0].item()
+            w = rgb.shape[2]
+            import math
+            fov_x = math.degrees(2 * math.atan(w / (2 * fx)))
+        out = self._moge2.infer(inp, fov_x=fov_x)  # type: ignore[union-attr]
+        depth = out["depth"]  # (B, H, W)
+        if was_unbatched:
+            depth = depth.squeeze(0)  # (H, W) only if we added the batch dim ourselves
+        return DepthEstimationResult(metric_depth=depth)
+
+    @torch.no_grad()
+    def _estimate_video(self, src: DepthEstimationInput) -> DepthEstimationResult:
+        """Run Pi3X (chunked) + MoGe-2 (per-frame) and fuse."""
+        frames = src.video_frame_list  # list of (H,W,3) float32 [0,1]
+        assert frames is not None
+        T = len(frames)
+
+        import torch.nn.functional as F_nn
+
+        frames_np = np.stack(frames, axis=0)  # (T,H,W,3)
+        frames_t = torch.from_numpy(frames_np).to(self.device).permute(0, 3, 1, 2)  # (T,3,H,W)
+        H_img, W_img = frames_np.shape[1], frames_np.shape[2]
+
+        # Pi3X requires H and W to be multiples of patch size 14
+        H_r = (H_img // 14) * 14
+        W_r = (W_img // 14) * 14
+        if H_r != H_img or W_r != W_img:
+            frames_pi3x = F_nn.interpolate(frames_t, size=(H_r, W_r), mode='bilinear', align_corners=False)
+        else:
+            frames_pi3x = frames_t
+
+        # Pi3X forward: (B, N, 3, H, W) -> local_points (B, N, H, W, 3), depth = z-component
+        # Process in chunks of 16 (ViT attention is O(N^2 x patches^2) — full 600+ frames OOM)
+        CHUNK, STRIDE = 16, 8
+        d_pi3x_accum = np.zeros((T, H_r, W_r), dtype=np.float32)
+        count = np.zeros(T, dtype=np.float32)
+        starts = list(range(0, max(T - CHUNK + 1, 1), STRIDE))
+        if not starts or starts[-1] + CHUNK < T:
+            starts.append(max(0, T - CHUNK))
+        for s in starts:
+            e = min(s + CHUNK, T)
+            chunk = frames_pi3x[s:e].unsqueeze(0)  # (1, n, 3, H_r, W_r)
+            out = self._pi3x(chunk)  # type: ignore[union-attr]
+            d_chunk = out["local_points"][0, :e-s, :, :, 2].cpu().numpy()  # (n, H_r, W_r)
+            d_pi3x_accum[s:e] += d_chunk
+            count[s:e] += 1
+        d_pi3x_r = d_pi3x_accum / np.maximum(count[:, None, None], 1.0)  # (T, H_r, W_r)
+
+        # Upsample Pi3X depth back to original resolution
+        if H_r != H_img or W_r != W_img:
+            d_pi3x = F_nn.interpolate(
+                torch.from_numpy(d_pi3x_r).unsqueeze(1).to(self.device),
+                size=(H_img, W_img), mode='bilinear', align_corners=False
+            ).squeeze(1).cpu().numpy()
+        else:
+            d_pi3x = d_pi3x_r
+
+        # MoGe-2: per-frame metric depth
+        fov_x = None
+        if src.intrinsics is not None:
+            fx = src.intrinsics[0].item()
+            w = frames_np.shape[2]
+            import math
+            fov_x = math.degrees(2 * math.atan(w / (2 * fx)))
+
+        d_moge_list = []
+        for i in range(T):
+            f = frames_t[i:i+1]
+            out = self._moge2.infer(f, fov_x=fov_x)  # type: ignore[union-attr]
+            d_moge_list.append(out["depth"].squeeze(0).cpu().numpy())
+        d_moge = np.stack(d_moge_list, axis=0)  # (T,H,W)
+
+        # EMA scale fusion
+        scale = _fuse_ema(d_pi3x, d_moge, self.ema_momentum)  # (T,)
+        metric_depth = d_pi3x * scale[:, None, None]
+
+        return DepthEstimationResult(
+            metric_depth=torch.from_numpy(metric_depth.astype(np.float32)).to(self.device)
+        )

--- a/vipe/priors/depth/priorda/sparse_sampler.py
+++ b/vipe/priors/depth/priorda/sparse_sampler.py
@@ -12,9 +12,10 @@ import torch
 import torch.nn.functional as F
 from PIL import Image
 
+# OSError covers wheels compiled against a different torch ABI failing to load.
 try:
     import torch_cluster
-except ImportError:
+except (ImportError, OSError):
     torch_cluster = None
 
 

--- a/vipe/priors/dynamic_mask/__init__.py
+++ b/vipe/priors/dynamic_mask/__init__.py
@@ -1,0 +1,24 @@
+"""Automatic dynamic-object mask estimation via optical-flow motion scores.
+
+Algorithm overview (after Sundaram-style fwd/bwd consistency + Sampson-error scoring):
+
+1. For every consecutive frame pair compute forward and backward optical flow
+   with a class-agnostic flow model (default: SEA-RAFT).
+2. Build per-pixel forward/backward consistency masks using the standard
+   |fwd + bwd(warp)|^2 < alpha * (|fwd|^2 + |bwd(warp)|^2) + beta criterion.
+3. For every frame fit a fundamental matrix between consistent correspondences
+   (using RANSAC), then evaluate the Sampson reprojection error of every pixel.
+   The error indicates how much that pixel's motion deviates from the
+   epipolar geometry of the dominant (background) flow.
+4. For every tracked instance, average the per-pixel Sampson error over its
+   support, weighting by flow confidence. Frames where the error is too small
+   (i.e. the object happens to move with the camera) are filtered out so static
+   chunks don't dilute the score.
+5. Select instances whose final motion score exceeds a fraction of the maximum
+   as dynamic. Their union is the final dynamic mask.
+"""
+
+from .pipeline import DynamicMaskPipeline
+
+
+__all__ = ["DynamicMaskPipeline"]

--- a/vipe/priors/dynamic_mask/flow_consistency.py
+++ b/vipe/priors/dynamic_mask/flow_consistency.py
@@ -1,0 +1,64 @@
+"""Forward-backward optical-flow consistency masks."""
+
+import torch
+import torch.nn.functional as F
+
+
+def _warp_with_flow(field: torch.Tensor, flow: torch.Tensor) -> torch.Tensor:
+    """Backward-warp `field` by `flow`.
+
+    field: (B, C, H, W). flow: (B, 2, H, W) in pixel units (dx, dy).
+    For each output pixel (y, x) returns field at (y + dy, x + dx),
+    using bilinear sampling.
+    """
+    B, _, H, W = flow.shape
+    device = flow.device
+    yy, xx = torch.meshgrid(
+        torch.arange(H, device=device, dtype=flow.dtype),
+        torch.arange(W, device=device, dtype=flow.dtype),
+        indexing="ij",
+    )
+    base_grid = torch.stack([xx, yy], dim=0).unsqueeze(0).expand(B, -1, -1, -1)  # (B, 2, H, W)
+    sample = base_grid + flow
+    # Convert pixel coords to normalized [-1, 1] grid_sample format.
+    sample_x = 2.0 * sample[:, 0] / (W - 1) - 1.0
+    sample_y = 2.0 * sample[:, 1] / (H - 1) - 1.0
+    grid = torch.stack([sample_x, sample_y], dim=-1)  # (B, H, W, 2)
+    return F.grid_sample(field, grid, mode="bilinear", padding_mode="border", align_corners=True)
+
+
+def forward_backward_consistency(
+    fwd_flow: torch.Tensor,
+    bwd_flow: torch.Tensor,
+    alpha: float = 0.5,
+    beta: float = 0.5,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute consistency masks for both directions of a flow pair.
+
+    A pixel x in frame A is considered consistent w.r.t. its forward flow
+    f_AB iff   |f_AB(x) + f_BA(x + f_AB(x))|^2 < alpha * (|f_AB(x)|^2 +
+    |f_BA(x + f_AB(x))|^2) + beta.
+
+    Args:
+        fwd_flow: (B, 2, H, W) flow from A -> B.
+        bwd_flow: (B, 2, H, W) flow from B -> A.
+
+    Returns:
+        fwd_mask: (B, H, W) bool, True where A's forward flow is consistent.
+        bwd_mask: (B, H, W) bool, True where B's backward flow is consistent.
+    """
+    bwd_warped_to_a = _warp_with_flow(bwd_flow, fwd_flow)  # B->A flow sampled at x + f_AB(x)
+    cycle_a = fwd_flow + bwd_warped_to_a
+    cycle_a_sq = (cycle_a**2).sum(dim=1)
+    fwd_mag_sq = (fwd_flow**2).sum(dim=1)
+    bwd_mag_sq_at_a = (bwd_warped_to_a**2).sum(dim=1)
+    fwd_mask = cycle_a_sq < alpha * (fwd_mag_sq + bwd_mag_sq_at_a) + beta
+
+    fwd_warped_to_b = _warp_with_flow(fwd_flow, bwd_flow)
+    cycle_b = bwd_flow + fwd_warped_to_b
+    cycle_b_sq = (cycle_b**2).sum(dim=1)
+    bwd_mag_sq = (bwd_flow**2).sum(dim=1)
+    fwd_mag_sq_at_b = (fwd_warped_to_b**2).sum(dim=1)
+    bwd_mask = cycle_b_sq < alpha * (bwd_mag_sq + fwd_mag_sq_at_b) + beta
+
+    return fwd_mask, bwd_mask

--- a/vipe/priors/dynamic_mask/pipeline.py
+++ b/vipe/priors/dynamic_mask/pipeline.py
@@ -1,0 +1,279 @@
+"""End-to-end dynamic-mask estimation: flow -> consistency -> Sampson -> per-instance scoring."""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import torch
+
+from tqdm import tqdm
+
+from ..flow.base import OpticalFlowModel
+from .flow_consistency import forward_backward_consistency
+from .sampson import sampson_error_for_frame
+
+
+@dataclass
+class DynamicMaskOutput:
+    masks: torch.Tensor  # (S, H, W) bool — final dynamic mask per frame
+    sampson: torch.Tensor  # (S, H, W) float — Sampson error per pixel per frame
+    fwd_consistency: torch.Tensor  # (S, H, W) bool — forward consistency mask
+    bwd_consistency: torch.Tensor  # (S, H, W) bool — backward consistency mask
+    instance_motion_scores: dict[int, float] = field(default_factory=dict)
+    selected_instances: list[int] = field(default_factory=list)
+
+
+class DynamicMaskPipeline:
+    """Computes per-frame dynamic-object masks from RGB frames + per-frame
+    instance segmentations (with consistent IDs across frames).
+
+    Args:
+        flow_model: an `OpticalFlowModel` to compute pairwise optical flow.
+        flow_alpha, flow_beta: parameters of the fwd/bwd consistency check.
+        ransac_threshold: RANSAC reprojection threshold for the fundamental
+            matrix fit (in normalized [-1, 1] coords).
+        keep_motion_ratio: an instance is dynamic iff its motion score exceeds
+            `keep_motion_ratio * max(motion_scores)`.
+        min_area_ratio: drop instances smaller than this fraction of the image.
+        filter_time_thres: per-frame Sampson errors below this are zeroed before
+            averaging across time, so frames where an object is momentarily
+            static do not lower its score.
+        sampson_max_points: cap on points fed to RANSAC.
+        device: torch device for flow + tensors.
+    """
+
+    def __init__(
+        self,
+        flow_model: OpticalFlowModel,
+        flow_alpha: float = 0.5,
+        flow_beta: float = 0.5,
+        ransac_threshold: float = 0.01,
+        keep_motion_ratio: float = 0.25,
+        min_area_ratio: float = 1e-4,
+        filter_time_thres: float = 1e-4,
+        sampson_max_points: int = 10000,
+        device: torch.device | str = "cuda",
+    ) -> None:
+        self.flow_model = flow_model
+        self.flow_alpha = flow_alpha
+        self.flow_beta = flow_beta
+        self.ransac_threshold = ransac_threshold
+        self.keep_motion_ratio = keep_motion_ratio
+        self.min_area_ratio = min_area_ratio
+        self.filter_time_thres = filter_time_thres
+        self.sampson_max_points = sampson_max_points
+        self.device = torch.device(device)
+
+    @torch.no_grad()
+    def _compute_pairwise_flow(self, frames: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """frames: (S, 3, H, W) in [0, 1]. Returns fwd, bwd flow each of shape
+        (S - 1, 2, H, W)."""
+        S = frames.shape[0]
+        fwds = []
+        bwds = []
+        for i in tqdm(range(S - 1), desc="SEA-RAFT pairwise flow"):
+            a = frames[i : i + 1].to(self.device)
+            b = frames[i + 1 : i + 2].to(self.device)
+            fwds.append(self.flow_model.estimate(a, b).cpu())
+            bwds.append(self.flow_model.estimate(b, a).cpu())
+        fwd = torch.cat(fwds, dim=0)
+        bwd = torch.cat(bwds, dim=0)
+        return fwd, bwd
+
+    @torch.no_grad()
+    def _compute_consistency_masks(
+        self, fwd_flow: torch.Tensor, bwd_flow: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """fwd_flow, bwd_flow: (S - 1, 2, H, W). Returns:
+
+        per_frame_fwd_mask: (S, H, W) bool — pixels in frame i whose forward
+            flow to frame i+1 is consistent (last frame = all True).
+        per_frame_bwd_mask: (S, H, W) bool — pixels in frame i whose backward
+            flow to frame i-1 is consistent (first frame = all True).
+        """
+        # Process in chunks to bound peak GPU mem.
+        S_minus_1 = fwd_flow.shape[0]
+        H, W = fwd_flow.shape[-2:]
+        fwd_masks = torch.empty((S_minus_1, H, W), dtype=torch.bool)
+        bwd_masks_pair = torch.empty((S_minus_1, H, W), dtype=torch.bool)
+        chunk = 8
+        for s in range(0, S_minus_1, chunk):
+            e = min(s + chunk, S_minus_1)
+            f_a, f_b = forward_backward_consistency(
+                fwd_flow[s:e].to(self.device),
+                bwd_flow[s:e].to(self.device),
+                alpha=self.flow_alpha,
+                beta=self.flow_beta,
+            )
+            fwd_masks[s:e] = f_a.cpu()
+            bwd_masks_pair[s:e] = f_b.cpu()
+
+        # Pad to (S, H, W).
+        per_frame_fwd_mask = torch.cat(
+            [fwd_masks, torch.ones((1, H, W), dtype=torch.bool)], dim=0
+        )
+        per_frame_bwd_mask = torch.cat(
+            [torch.ones((1, H, W), dtype=torch.bool), bwd_masks_pair], dim=0
+        )
+        return per_frame_fwd_mask, per_frame_bwd_mask
+
+    @torch.no_grad()
+    def _compute_sampson_errors(
+        self,
+        fwd_flow: torch.Tensor,
+        bwd_flow: torch.Tensor,
+        per_frame_fwd_mask: torch.Tensor,
+        per_frame_bwd_mask: torch.Tensor,
+        H: int,
+        W: int,
+    ) -> torch.Tensor:
+        """Returns (S, H, W) Sampson-error tensor on CPU (float32)."""
+        S = per_frame_fwd_mask.shape[0]
+        fwd_flow_np = fwd_flow.permute(0, 2, 3, 1).numpy()  # (S-1, H, W, 2)
+        bwd_flow_np = bwd_flow.permute(0, 2, 3, 1).numpy()
+        fwd_mask_np = per_frame_fwd_mask.numpy()
+        bwd_mask_np = per_frame_bwd_mask.numpy()
+
+        out = np.zeros((S, H, W), dtype=np.float32)
+        for i in tqdm(range(S), desc="Sampson per frame"):
+            fwd_f = fwd_flow_np[i] if i < S - 1 else None
+            fwd_m = fwd_mask_np[i] if i < S - 1 else None
+            bwd_f = bwd_flow_np[i - 1] if i > 0 else None
+            bwd_m = bwd_mask_np[i] if i > 0 else None
+            out[i] = sampson_error_for_frame(
+                fwd_flow=fwd_f,
+                fwd_mask=fwd_m,
+                bwd_flow=bwd_f,
+                bwd_mask=bwd_m,
+                H=H,
+                W=W,
+                max_points=self.sampson_max_points,
+                use_ransac=True,
+                ransac_threshold=self.ransac_threshold,
+            )
+        return torch.from_numpy(out)
+
+    def _compute_motion_scores(
+        self,
+        sampson: torch.Tensor,
+        per_frame_fwd_mask: torch.Tensor,
+        per_frame_bwd_mask: torch.Tensor,
+        instances: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Aggregate the per-pixel Sampson error to a per-instance motion score.
+
+        Args:
+            sampson: (S, H, W) float CPU.
+            per_frame_fwd_mask, per_frame_bwd_mask: (S, H, W) bool CPU.
+            instances: (S, H, W) int CPU. 0 = background.
+
+        Returns:
+            obj_ids: (O,) long, the unique non-zero instance ids.
+            motion_scores: (O,) float, average Sampson error per object.
+        """
+        unique_ids = torch.unique(instances)
+        unique_ids = unique_ids[unique_ids != 0]
+
+        if unique_ids.numel() == 0:
+            return unique_ids, torch.zeros(0)
+
+        flow_mask = per_frame_fwd_mask & per_frame_bwd_mask  # (S, H, W)
+
+        s, H, W = sampson.shape
+        device = self.device
+
+        # We chunk over objects (and over time) to bound memory.
+        scores = torch.zeros(len(unique_ids), dtype=torch.float32)
+
+        sampson_g = sampson.to(device)
+        flow_mask_g = flow_mask.to(device)
+        instances_g = instances.to(device)
+
+        for k, obj_id in enumerate(unique_ids.tolist()):
+            obj_mask = (instances_g == obj_id) & flow_mask_g  # (S, H, W) bool
+            denom = obj_mask.float().sum(dim=(1, 2)).clamp(min=1.0)
+            per_frame_err = (sampson_g * obj_mask.float()).sum(dim=(1, 2)) / denom  # (S,)
+            valid = per_frame_err >= self.filter_time_thres
+            n_valid = valid.float().sum().clamp(min=1.0)
+            scores[k] = (per_frame_err * valid.float()).sum().item() / n_valid.item()
+
+        return unique_ids, scores
+
+    @torch.no_grad()
+    def compute(
+        self,
+        frames: torch.Tensor,
+        instances: torch.Tensor,
+    ) -> DynamicMaskOutput:
+        """Run the full pipeline.
+
+        Args:
+            frames: (S, 3, H, W) float in [0, 1].
+            instances: (S, H, W) int — instance map per frame, 0 = background,
+                instance ids must be consistent across frames.
+
+        Returns:
+            `DynamicMaskOutput`.
+        """
+        S, _, H, W = frames.shape
+        assert instances.shape == (S, H, W), f"instances shape mismatch: {instances.shape}"
+
+        fwd_flow, bwd_flow = self._compute_pairwise_flow(frames)
+        per_frame_fwd_mask, per_frame_bwd_mask = self._compute_consistency_masks(fwd_flow, bwd_flow)
+        sampson = self._compute_sampson_errors(
+            fwd_flow, bwd_flow, per_frame_fwd_mask, per_frame_bwd_mask, H, W
+        )
+
+        # Drop tiny instances by area before scoring.
+        unique_ids = torch.unique(instances)
+        unique_ids = unique_ids[unique_ids != 0]
+        keep_ids = []
+        total_pixels = float(S * H * W)
+        for obj_id in unique_ids.tolist():
+            area = float((instances == obj_id).sum().item())
+            if area / total_pixels >= self.min_area_ratio:
+                keep_ids.append(obj_id)
+        if not keep_ids:
+            return DynamicMaskOutput(
+                masks=torch.zeros((S, H, W), dtype=torch.bool),
+                sampson=sampson,
+                fwd_consistency=per_frame_fwd_mask,
+                bwd_consistency=per_frame_bwd_mask,
+            )
+
+        keep_instances = torch.zeros_like(instances)
+        for new_id, old_id in enumerate(keep_ids, start=1):
+            keep_instances[instances == old_id] = new_id
+
+        obj_ids, motion_scores = self._compute_motion_scores(
+            sampson, per_frame_fwd_mask, per_frame_bwd_mask, keep_instances
+        )
+
+        # Map obj_ids (re-numbered 1..K) back to original ids.
+        new_to_old = {new_id: old_id for new_id, old_id in enumerate(keep_ids, start=1)}
+        score_dict = {new_to_old[int(i)]: float(s) for i, s in zip(obj_ids.tolist(), motion_scores.tolist())}
+
+        # Threshold-based selection.
+        if motion_scores.numel() == 0 or motion_scores.max().item() <= 0.0:
+            selected = []
+        else:
+            thr = motion_scores.max().item() * self.keep_motion_ratio
+            selected_new_ids = [int(obj_ids[i].item()) for i in range(len(obj_ids)) if motion_scores[i].item() > thr]
+            selected = [new_to_old[i] for i in selected_new_ids]
+
+        if selected:
+            sel_set = set(selected)
+            sel_keep_idx = [i for i, oid in enumerate(keep_ids, start=1) if oid in sel_set]
+            sel_mask = torch.zeros((S, H, W), dtype=torch.bool)
+            for idx in sel_keep_idx:
+                sel_mask |= keep_instances == idx
+        else:
+            sel_mask = torch.zeros((S, H, W), dtype=torch.bool)
+
+        return DynamicMaskOutput(
+            masks=sel_mask,
+            sampson=sampson,
+            fwd_consistency=per_frame_fwd_mask,
+            bwd_consistency=per_frame_bwd_mask,
+            instance_motion_scores=score_dict,
+            selected_instances=selected,
+        )

--- a/vipe/priors/dynamic_mask/pipeline.py
+++ b/vipe/priors/dynamic_mask/pipeline.py
@@ -15,6 +15,7 @@ from .sampson import sampson_error_for_frame
 @dataclass
 class DynamicMaskOutput:
     masks: torch.Tensor  # (S, H, W) bool — final dynamic mask per frame
+    optical_flow: torch.Tensor  # (S, H, W, 4) float — [fwd_dx, fwd_dy, bwd_dx, bwd_dy] in pixels
     sampson: torch.Tensor  # (S, H, W) float — Sampson error per pixel per frame
     fwd_consistency: torch.Tensor  # (S, H, W) bool — forward consistency mask
     bwd_consistency: torch.Tensor  # (S, H, W) bool — backward consistency mask
@@ -218,6 +219,13 @@ class DynamicMaskPipeline:
         assert instances.shape == (S, H, W), f"instances shape mismatch: {instances.shape}"
 
         fwd_flow, bwd_flow = self._compute_pairwise_flow(frames)
+        optical_flow = torch.cat(
+            [
+                torch.nn.functional.pad(fwd_flow, (0, 0, 0, 0, 0, 0, 0, 1)),
+                torch.nn.functional.pad(bwd_flow, (0, 0, 0, 0, 0, 0, 1, 0)),
+            ],
+            dim=1,
+        ).permute(0, 2, 3, 1)
         per_frame_fwd_mask, per_frame_bwd_mask = self._compute_consistency_masks(fwd_flow, bwd_flow)
         sampson = self._compute_sampson_errors(
             fwd_flow, bwd_flow, per_frame_fwd_mask, per_frame_bwd_mask, H, W
@@ -235,6 +243,7 @@ class DynamicMaskPipeline:
         if not keep_ids:
             return DynamicMaskOutput(
                 masks=torch.zeros((S, H, W), dtype=torch.bool),
+                optical_flow=optical_flow,
                 sampson=sampson,
                 fwd_consistency=per_frame_fwd_mask,
                 bwd_consistency=per_frame_bwd_mask,
@@ -271,6 +280,7 @@ class DynamicMaskPipeline:
 
         return DynamicMaskOutput(
             masks=sel_mask,
+            optical_flow=optical_flow,
             sampson=sampson,
             fwd_consistency=per_frame_fwd_mask,
             bwd_consistency=per_frame_bwd_mask,

--- a/vipe/priors/dynamic_mask/sampson.py
+++ b/vipe/priors/dynamic_mask/sampson.py
@@ -1,0 +1,120 @@
+"""Sampson reprojection-error scoring of optical flow vs. fitted fundamental matrix."""
+
+import cv2
+import numpy as np
+
+
+def fit_fundamental_and_sampson(
+    pts1: np.ndarray,
+    pts2: np.ndarray,
+    valid_mask: np.ndarray,
+    H: int,
+    W: int,
+    max_points: int = 5000,
+    use_ransac: bool = True,
+    ransac_threshold: float = 0.01,
+    ransac_confidence: float = 0.99,
+    ransac_max_iters: int = 1000,
+    rng: np.random.Generator | None = None,
+) -> np.ndarray:
+    """Fit a fundamental matrix on (pts1, pts2) restricted to `valid_mask`,
+    then return a per-pixel Sampson error map of shape (H, W).
+
+    Coordinates of `pts1` and `pts2` are assumed already normalized to
+    [-1, 1] x [-1, 1] (which makes RANSAC thresholds resolution-independent).
+    Pixels outside the consistency mask are zeroed in the output.
+    """
+    flat_mask = valid_mask.reshape(-1).astype(bool)
+    if flat_mask.sum() < 8:
+        return np.zeros((H, W), dtype=np.float32)
+
+    p1 = pts1[flat_mask]
+    p2 = pts2[flat_mask]
+
+    if len(p1) > max_points:
+        if rng is None:
+            rng = np.random.default_rng()
+        idx = rng.choice(len(p1), size=max_points, replace=False)
+        p1 = p1[idx]
+        p2 = p2[idx]
+
+    if use_ransac:
+        F, _ = cv2.findFundamentalMat(
+            p1.astype(np.float32),
+            p2.astype(np.float32),
+            cv2.FM_RANSAC,
+            ransacReprojThreshold=ransac_threshold,
+            confidence=ransac_confidence,
+            maxIters=ransac_max_iters,
+        )
+    else:
+        F, _ = cv2.findFundamentalMat(p1.astype(np.float32), p2.astype(np.float32), cv2.FM_LMEDS)
+
+    if F is None:
+        return np.zeros((H, W), dtype=np.float32)
+
+    F = F.astype(np.float32)
+    ones = np.ones((pts1.shape[0], 1), dtype=np.float32)
+    x1h = np.concatenate([pts1.astype(np.float32), ones], axis=1)
+    x2h = np.concatenate([pts2.astype(np.float32), ones], axis=1)
+    Fx1 = x1h @ F.T
+    Fx2 = x2h @ F
+    num = (np.sum(x2h * Fx1, axis=1)) ** 2
+    den = Fx1[:, 0] ** 2 + Fx1[:, 1] ** 2 + Fx2[:, 0] ** 2 + Fx2[:, 1] ** 2 + 1e-8
+    err = num / den
+    err = err.reshape(H, W) * valid_mask.astype(np.float32)
+    return err.astype(np.float32)
+
+
+def sampson_error_for_frame(
+    fwd_flow: np.ndarray | None,
+    fwd_mask: np.ndarray | None,
+    bwd_flow: np.ndarray | None,
+    bwd_mask: np.ndarray | None,
+    H: int,
+    W: int,
+    **kwargs,
+) -> np.ndarray:
+    """Compute the per-pixel motion-likelihood error for a single frame,
+    by taking the max of forward and backward Sampson errors (sqrt'd to
+    behave more linearly), as in dyn_mask.py.
+
+    Either direction may be None (e.g., the very first / last frame).
+    """
+    yy, xx = np.meshgrid(
+        np.arange(H, dtype=np.float32),
+        np.arange(W, dtype=np.float32),
+        indexing="ij",
+    )
+    xn = 2 * (xx + 0.5) / W - 1
+    yn = 2 * (yy + 0.5) / H - 1
+    pts1 = np.stack([xn.ravel(), yn.ravel()], axis=-1).astype(np.float32)
+
+    err_list: list[np.ndarray] = []
+
+    if fwd_flow is not None and fwd_mask is not None:
+        flow_n = np.stack(
+            [
+                2.0 * fwd_flow[..., 0] / (W - 1),
+                2.0 * fwd_flow[..., 1] / (H - 1),
+            ],
+            axis=-1,
+        ).astype(np.float32)
+        pts2 = (pts1 + flow_n.reshape(-1, 2)).astype(np.float32)
+        err_list.append(fit_fundamental_and_sampson(pts1, pts2, fwd_mask, H, W, **kwargs))
+
+    if bwd_flow is not None and bwd_mask is not None:
+        flow_n = np.stack(
+            [
+                2.0 * bwd_flow[..., 0] / (W - 1),
+                2.0 * bwd_flow[..., 1] / (H - 1),
+            ],
+            axis=-1,
+        ).astype(np.float32)
+        pts2 = (pts1 + flow_n.reshape(-1, 2)).astype(np.float32)
+        err_list.append(fit_fundamental_and_sampson(pts1, pts2, bwd_mask, H, W, **kwargs))
+
+    if not err_list:
+        return np.zeros((H, W), dtype=np.float32)
+    err = np.maximum.reduce(err_list)
+    return np.sqrt(err.clip(min=0)).astype(np.float32)

--- a/vipe/priors/flow/__init__.py
+++ b/vipe/priors/flow/__init__.py
@@ -1,0 +1,5 @@
+from .base import OpticalFlowModel
+from .sea_raft_model import SeaRaftModel
+
+
+__all__ = ["OpticalFlowModel", "SeaRaftModel"]

--- a/vipe/priors/flow/base.py
+++ b/vipe/priors/flow/base.py
@@ -1,0 +1,21 @@
+from abc import ABC, abstractmethod
+
+import torch
+
+
+class OpticalFlowModel(ABC):
+    """Abstract base for pairwise optical flow estimators."""
+
+    @abstractmethod
+    def estimate(self, image1: torch.Tensor, image2: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            image1, image2: (B, 3, H, W) float tensors in [0, 1] on the model device.
+
+        Returns:
+            flow: (B, 2, H, W) float tensor on the model device.
+                  flow[:, 0] is horizontal displacement (in pixels),
+                  flow[:, 1] is vertical displacement (in pixels),
+                  s.t. image1[..., y, x] corresponds to image2[..., y + dy, x + dx].
+        """
+        ...

--- a/vipe/priors/flow/sea_raft/LICENSE
+++ b/vipe/priors/flow/sea_raft/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, Princeton Vision & Learning Lab
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vipe/priors/flow/sea_raft/__init__.py
+++ b/vipe/priors/flow/sea_raft/__init__.py
@@ -1,0 +1,8 @@
+# Vendored from https://github.com/princeton-vl/SEA-RAFT (BSD 3-Clause).
+# Original copyright: 2024 Princeton Vision & Learning Lab. See LICENSE in this directory.
+# Local imports were rewritten to be package-relative.
+
+from .raft import RAFT
+
+
+__all__ = ["RAFT"]

--- a/vipe/priors/flow/sea_raft/corr.py
+++ b/vipe/priors/flow/sea_raft/corr.py
@@ -1,0 +1,206 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from .raft_utils import coords_grid, bilinear_sampler
+
+try:
+    import alt_cuda_corr
+except:
+    # alt_cuda_corr is not compiled
+    pass
+
+def coords_feature(fmap, b, x, y):
+    H, W = fmap.shape[2:]
+    mask = (x >= 0) & (x < W) & (y >= 0) & (y < H)
+    b = b.long()
+    x = torch.clamp(x, 0, W-1).long()
+    y = torch.clamp(y, 0, H-1).long()
+    res = fmap[b, :, y, x] * mask.float().unsqueeze(1)
+    return res
+
+def bilinear_sampling(fmap, coords):
+    """coords: (bhw)"""
+    device = fmap.device
+    offset = (coords - coords.floor()).to(device)
+    dx, dy = offset[:, 1, None], offset[:, 2, None]
+    b = coords[:, 0].long()
+    x0, y0 = coords[:, 1].floor(), coords[:, 2].floor()
+    x1, y1 = x0 + 1, y0 + 1
+    f00 = (1 - dy) * (1 - dx) * coords_feature(fmap, b, x0, y0)
+    f01 = (1 - dy) * dx * coords_feature(fmap, b, x0, y1)
+    f10 = dy * (1 - dx) * coords_feature(fmap, b, x1, y0)
+    f11 = dy * dx * coords_feature(fmap, b, x1, y1)
+    return f00 + f01 + f10 + f11
+
+def coords_corr(corr, idx, b, x, y):
+    # corr: [N, H, W, H, W]
+    H, W = corr.shape[-2:]
+    mask = (x >= 0) & (x < W) & (y >= 0) & (y < H)
+    b = b.long()
+    idx = idx.long()
+    x = torch.clamp(x, 0, W-1).long()
+    y = torch.clamp(y, 0, H-1).long()
+    res = corr[b, idx[:, 2], idx[:, 1], y, x] * mask.float()
+    print(mask.requires_grad, x.requires_grad, y.requires_grad, res.requires_grad)
+    return res
+
+def bilinear_sampling_corr(corr, idx1, idx2):
+    """idx1: [M, (bhw)], idx2: [M, n_points, (bhw)]"""
+    M, n_points = idx2.shape[:2]
+    # reshape idx: [M * n_points, (bhw)]
+    idx1 = idx1.unsqueeze(1).repeat(1, n_points, 1).view(-1, 3)
+    idx2 = idx2.view(-1, 3)
+    device = corr.device
+    offset = idx2 - idx2.floor()
+    dx, dy = offset[:, 1], offset[:, 2]
+    b = idx2[:, 0].long()
+    x0, y0 = idx2[:, 1].floor(), idx2[:, 2].floor()
+    x1, y1 = x0 + 1, y0 + 1
+    f00 = (1 - dy) * (1 - dx) * coords_corr(corr, idx1, b, x0, y0)
+    # f01 = (1 - dy) * dx * coords_corr(corr, idx1, b, x0, y1)
+    # f10 = dy * (1 - dx) * coords_corr(corr, idx1, b, x1, y0)
+    # f11 = dy * dx * coords_corr(corr, idx1, b, x1, y1)
+    # res = f00 + f01 + f10 + f11\
+    res = f00
+    return res.view(M, n_points)
+
+class CorrBlock:
+    def __init__(self, fmap1, fmap2, args):
+        self.num_levels = args.corr_levels
+        self.radius = args.corr_radius
+        self.args = args
+        self.corr_pyramid = []
+        # all pairs correlation
+        for i in range(self.num_levels):
+            corr = CorrBlock.corr(fmap1, fmap2, 1)
+            batch, h1, w1, dim, h2, w2 = corr.shape
+            corr = corr.reshape(batch*h1*w1, dim, h2, w2)
+            fmap2 = F.interpolate(fmap2, scale_factor=0.5, mode='bilinear', align_corners=False)
+            self.corr_pyramid.append(corr)
+
+    def __call__(self, coords, dilation=None):
+        r = self.radius
+        coords = coords.permute(0, 2, 3, 1)
+        batch, h1, w1, _ = coords.shape
+
+        if dilation is None:
+            dilation = torch.ones(batch, 1, h1, w1, device=coords.device)
+
+        # print(dilation.max(), dilation.mean(), dilation.min())
+        out_pyramid = []
+        for i in range(self.num_levels):
+            corr = self.corr_pyramid[i]
+            device = coords.device
+            dx = torch.linspace(-r, r, 2*r+1, device=device)
+            dy = torch.linspace(-r, r, 2*r+1, device=device)
+            delta = torch.stack(torch.meshgrid(dy, dx), axis=-1)
+            delta_lvl = delta.view(1, 2*r+1, 2*r+1, 2)
+            delta_lvl = delta_lvl * dilation.view(batch * h1 * w1, 1, 1, 1)
+            centroid_lvl = coords.reshape(batch*h1*w1, 1, 1, 2) / 2**i
+            coords_lvl = centroid_lvl + delta_lvl
+            corr = bilinear_sampler(corr, coords_lvl)
+            corr = corr.view(batch, h1, w1, -1)
+            out_pyramid.append(corr)
+
+        out = torch.cat(out_pyramid, dim=-1)
+        out = out.permute(0, 3, 1, 2).contiguous().float()  
+        return out
+
+    @staticmethod
+    def corr(fmap1, fmap2, num_head):
+        batch, dim, h1, w1 = fmap1.shape
+        h2, w2 = fmap2.shape[2:]
+        fmap1 = fmap1.view(batch, num_head, dim // num_head, h1*w1)
+        fmap2 = fmap2.view(batch, num_head, dim // num_head, h2*w2) 
+        corr = fmap1.transpose(2, 3) @ fmap2
+        corr = corr.reshape(batch, num_head, h1, w1, h2, w2).permute(0, 2, 3, 1, 4, 5)
+        return corr  / torch.sqrt(torch.tensor(dim).float())
+
+# class CorrBlock:
+#     def __init__(self, context, fmap1, fmap2, args):
+#         self.num_levels = args.corr_levels
+#         self.radius = args.corr_radius
+#         self.args = args
+#         self.context = context
+#         self.corr_pyramid = []
+#         # all pairs correlation
+#         for i in range(self.num_levels):
+#             corr = CorrBlock.corr(fmap1, fmap2)
+#             batch, h1, w1, h2, w2 = corr.shape
+#             fmap2 = F.interpolate(fmap2, scale_factor=0.5, mode='bilinear', align_corners=False)
+#             self.corr_pyramid.append(corr)
+
+#     def __call__(self, idx1, idx2):
+#         # idx: [M, (bhw)]
+#         idx1 = idx1.detach()
+#         idx2 = idx2.detach()
+#         M = idx1.shape[0]
+#         r = self.radius
+#         n_points = (2 * self.radius + 1) ** 2
+#         inp = coords_feature(self.context, idx1[:, 0], idx1[:, 1], idx1[:, 2])
+#         device = idx1.device
+#         corr_list = []
+#         for i in range(self.num_levels):
+#             dx = torch.linspace(-r, r, 2*r+1, device=device)
+#             dy = torch.linspace(-r, r, 2*r+1, device=device)
+#             delta = torch.stack(torch.meshgrid(dy, dx), axis=-1)
+#             delta_lvl = delta.view(1, n_points, 2)
+#             # delta_lvl: [..., (bhw)]
+#             delta_lvl = torch.cat([torch.zeros([1, n_points, 1], device=device), delta_lvl], dim=-1)
+#             centroid_lvl = idx2
+#             centroid_lvl[:, 1:] /= 2**i
+#             coords_lvl = centroid_lvl.unsqueeze(1) + delta_lvl
+#             corr = bilinear_sampling_corr(self.corr_pyramid[i], idx1, coords_lvl)
+#             corr_list.append(corr)
+
+#         corr = torch.cat(corr_list, dim=1)
+#         return inp, corr
+
+#     def corr(fmap1, fmap2):
+#         batch, dim, h1, w1 = fmap1.shape
+#         h2, w2 = fmap2.shape[2:]
+#         fmap1 = fmap1.view(batch, dim, h1*w1)
+#         fmap2 = fmap2.view(batch, dim, h2*w2) 
+#         corr = fmap1.transpose(1, 2) @ fmap2
+#         corr = corr.reshape(batch, h1, w1, h2, w2)
+#         return corr  / torch.sqrt(torch.tensor(dim).float())
+
+# class FastCorr:
+#     def __init__(self, context, fmap1, fmap2, args):
+#         self.num_levels = args.corr_levels
+#         self.radius = args.corr_radius
+#         self.num_head = args.num_head
+#         self.fmap1 = fmap1
+#         self.context = context
+#         self.fmap2_pyramid = [fmap2]
+#         for i in range(self.num_levels - 1):
+#             fmap2 = F.avg_pool2d(fmap2, 2, stride=2)
+#             self.fmap2_pyramid.append(fmap2)
+
+#     def __call__(self, idx1, idx2):
+#         # idx: [M, (bhw)]
+#         M = idx1.shape[0]
+#         r = self.radius
+#         n_points = (2 * self.radius + 1) ** 2
+#         inp = coords_feature(self.context, idx1[:, 0], idx1[:, 1], idx1[:, 2])
+#         f1 = coords_feature(self.fmap1, idx1[:, 0], idx1[:, 1], idx1[:, 2])
+#         corr_list = []
+#         for i in range(self.num_levels):
+#             device = idx1.device
+#             dx = torch.linspace(-r, r, 2*r+1, device=device)
+#             dy = torch.linspace(-r, r, 2*r+1, device=device)
+#             delta = torch.stack(torch.meshgrid(dy, dx), axis=-1)
+#             delta_lvl = delta.view(1, n_points, 2)
+#             # delta_lvl: [..., (bhw)]
+#             delta_lvl = torch.cat([torch.zeros([1, n_points, 1], device=device), delta_lvl], dim=-1)
+#             centroid_lvl = idx2
+#             centroid_lvl[:, 1:] /= 2**i
+#             coords_lvl = centroid_lvl.unsqueeze(1) + delta_lvl
+#             # f2: [M * n_points, C]
+#             f2 = bilinear_sampling(self.fmap2_pyramid[i], coords_lvl)
+#             f2 = f2.view(M, n_points, -1)
+#             corr = torch.einsum('mnc,mc->mn', f2, f1) / torch.sqrt(torch.tensor(f1.shape[-1]).float())
+#             corr_list.append(corr)
+
+#         corr = torch.cat(corr_list, dim=1)
+#         return inp, corr

--- a/vipe/priors/flow/sea_raft/extractor.py
+++ b/vipe/priors/flow/sea_raft/extractor.py
@@ -1,0 +1,87 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from .layer import BasicBlock, conv1x1, conv3x3
+
+class ResNetFPN(nn.Module):
+    """
+    ResNet18, output resolution is 1/8.
+    Each block has 2 layers.
+    """
+    def __init__(self, args, input_dim=3, output_dim=256, ratio=1.0, norm_layer=nn.BatchNorm2d, init_weight=False):
+        super().__init__()
+        # Config
+        block = BasicBlock
+        block_dims = args.block_dims
+        initial_dim = args.initial_dim
+        self.init_weight = init_weight
+        self.input_dim = input_dim
+        # Class Variable
+        self.in_planes = initial_dim
+        for i in range(len(block_dims)):
+            block_dims[i] = int(block_dims[i] * ratio)
+        # Networks
+        self.conv1 = nn.Conv2d(input_dim, initial_dim, kernel_size=7, stride=2, padding=3)
+        self.bn1 = norm_layer(initial_dim)
+        self.relu = nn.ReLU(inplace=True)
+        if args.pretrain == 'resnet34':
+            n_block = [3, 4, 6]
+        elif args.pretrain == 'resnet18':
+            n_block = [2, 2, 2]
+        else:
+            raise NotImplementedError       
+        self.layer1 = self._make_layer(block, block_dims[0], stride=1, norm_layer=norm_layer, num=n_block[0])  # 1/2
+        self.layer2 = self._make_layer(block, block_dims[1], stride=2, norm_layer=norm_layer, num=n_block[1])  # 1/4
+        self.layer3 = self._make_layer(block, block_dims[2], stride=2, norm_layer=norm_layer, num=n_block[2])  # 1/8
+        self.final_conv = conv1x1(block_dims[2], output_dim)
+        self._init_weights(args)
+
+    def _init_weights(self, args):
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, (nn.BatchNorm2d, nn.InstanceNorm2d, nn.GroupNorm)):
+                if m.weight is not None:
+                    nn.init.constant_(m.weight, 1)
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+
+        if self.init_weight:
+            from torchvision.models import resnet18, ResNet18_Weights, resnet34, ResNet34_Weights
+            if args.pretrain == 'resnet18':
+                pretrained_dict = resnet18(weights=ResNet18_Weights.IMAGENET1K_V1).state_dict()
+            else:
+                pretrained_dict = resnet34(weights=ResNet34_Weights.IMAGENET1K_V1).state_dict()
+            model_dict = self.state_dict()
+            pretrained_dict = {k: v for k, v in pretrained_dict.items() if k in model_dict}
+            if self.input_dim == 6:
+                for k, v in pretrained_dict.items():
+                    if k == 'conv1.weight':
+                        pretrained_dict[k] = torch.cat((v, v), dim=1)
+            model_dict.update(pretrained_dict)
+            self.load_state_dict(model_dict, strict=False)
+        
+
+    def _make_layer(self, block, dim, stride=1, norm_layer=nn.BatchNorm2d, num=2):
+        layers = []
+        layers.append(block(self.in_planes, dim, stride=stride, norm_layer=norm_layer))
+        for i in range(num - 1):
+            layers.append(block(dim, dim, stride=1, norm_layer=norm_layer))
+        self.in_planes = dim
+        return nn.Sequential(*layers)
+
+    def forward(self, x):
+        # ResNet Backbone
+        x = self.relu(self.bn1(self.conv1(x)))
+        for i in range(len(self.layer1)):
+            x = self.layer1[i](x)
+        for i in range(len(self.layer2)):
+            x = self.layer2[i](x)
+        for i in range(len(self.layer3)):
+            x = self.layer3[i](x)
+        # Output
+        output = self.final_conv(x)
+        return output

--- a/vipe/priors/flow/sea_raft/layer.py
+++ b/vipe/priors/flow/sea_raft/layer.py
@@ -1,0 +1,135 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import torch
+import math
+from torch.nn import Module, Dropout
+
+### Gradient Clipping and Zeroing Operations ###
+
+GRAD_CLIP = 0.1
+
+class GradClip(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x):
+        return x
+
+    @staticmethod
+    def backward(ctx, grad_x):
+        grad_x = torch.where(torch.isnan(grad_x), torch.zeros_like(grad_x), grad_x)
+        return grad_x.clamp(min=-0.01, max=0.01)
+
+class GradientClip(nn.Module):
+    def __init__(self):
+        super(GradientClip, self).__init__()
+
+    def forward(self, x):
+        return GradClip.apply(x)
+
+def _make_divisible(v, divisor, min_value=None):
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+class ConvNextBlock(nn.Module):
+    r""" ConvNeXt Block. There are two equivalent implementations:
+    (1) DwConv -> LayerNorm (channels_first) -> 1x1 Conv -> GELU -> 1x1 Conv; all in (N, C, H, W)
+    (2) DwConv -> Permute to (N, H, W, C); LayerNorm (channels_last) -> Linear -> GELU -> Linear; Permute back
+    We use (2) as we find it slightly faster in PyTorch
+    
+    Args:
+        dim (int): Number of input channels.
+        drop_path (float): Stochastic depth rate. Default: 0.0
+        layer_scale_init_value (float): Init value for Layer Scale. Default: 1e-6.
+    """
+    def __init__(self, dim, output_dim, layer_scale_init_value=1e-6):
+        super().__init__()
+        self.dwconv = nn.Conv2d(dim, dim, kernel_size=7, padding=3, groups=dim) # depthwise conv
+        self.norm = LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(dim, 4 * output_dim) # pointwise/1x1 convs, implemented with linear layers
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(4 * output_dim, dim)
+        self.gamma = nn.Parameter(layer_scale_init_value * torch.ones((dim)), 
+                                    requires_grad=True) if layer_scale_init_value > 0 else None
+        self.final = nn.Conv2d(dim, output_dim, kernel_size=1, padding=0)
+
+    def forward(self, x):
+        input = x
+        x = self.dwconv(x)
+        x = x.permute(0, 2, 3, 1) # (N, C, H, W) -> (N, H, W, C)
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+        if self.gamma is not None:
+            x = self.gamma * x
+        x = x.permute(0, 3, 1, 2) # (N, H, W, C) -> (N, C, H, W)
+        x = self.final(input + x)
+        return x
+    
+class LayerNorm(nn.Module):
+    r""" LayerNorm that supports two data formats: channels_last (default) or channels_first. 
+    The ordering of the dimensions in the inputs. channels_last corresponds to inputs with 
+    shape (batch_size, height, width, channels) while channels_first corresponds to inputs 
+    with shape (batch_size, channels, height, width).
+    """
+    def __init__(self, normalized_shape, eps=1e-6, data_format="channels_last"):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(normalized_shape))
+        self.bias = nn.Parameter(torch.zeros(normalized_shape))
+        self.eps = eps
+        self.data_format = data_format
+        if self.data_format not in ["channels_last", "channels_first"]:
+            raise NotImplementedError 
+        self.normalized_shape = (normalized_shape, )
+    
+    def forward(self, x):
+        if self.data_format == "channels_last":
+            return F.layer_norm(x, self.normalized_shape, self.weight, self.bias, self.eps)
+        elif self.data_format == "channels_first":
+            u = x.mean(1, keepdim=True)
+            s = (x - u).pow(2).mean(1, keepdim=True)
+            x = (x - u) / torch.sqrt(s + self.eps)
+            x = self.weight[:, None, None] * x + self.bias[:, None, None]
+            return x
+
+def conv1x1(in_planes, out_planes, stride=1):
+    """1x1 convolution without padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, padding=0)
+
+
+def conv3x3(in_planes, out_planes, stride=1):
+    """3x3 convolution with padding"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=3, stride=stride, padding=1)
+
+class BasicBlock(nn.Module):
+    def __init__(self, in_planes, planes, stride=1, norm_layer=nn.BatchNorm2d):
+        super().__init__()
+
+        # self.sparse = sparse
+        self.conv1 = conv3x3(in_planes, planes, stride)
+        self.conv2 = conv3x3(planes, planes)
+        self.bn1 = norm_layer(planes)
+        self.bn2 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        if stride == 1 and in_planes == planes:
+            self.downsample = None
+        else:
+            self.bn3 = norm_layer(planes)
+            self.downsample = nn.Sequential(
+                conv1x1(in_planes, planes, stride=stride),
+                self.bn3
+            )
+
+    def forward(self, x):
+        y = x
+        y = self.relu(self.bn1(self.conv1(y)))
+        y = self.relu(self.bn2(self.conv2(y)))
+        if self.downsample is not None:
+            x = self.downsample(x)
+        return self.relu(x+y)

--- a/vipe/priors/flow/sea_raft/raft.py
+++ b/vipe/priors/flow/sea_raft/raft.py
@@ -1,0 +1,161 @@
+import numpy as np
+import torch
+import math
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .update import BasicUpdateBlock
+from .corr import CorrBlock
+from .raft_utils import coords_grid, InputPadder
+from .extractor import ResNetFPN
+from .layer import conv1x1, conv3x3
+
+from huggingface_hub import PyTorchModelHubMixin
+
+class RAFT(
+    nn.Module,
+    PyTorchModelHubMixin, 
+    # optionally, you can add metadata which gets pushed to the model card
+    repo_url="https://github.com/princeton-vl/SEA-RAFT",
+    pipeline_tag="optical-flow-estimation",
+    license="bsd-3-clause",
+):
+    def __init__(self, args):
+        super().__init__()
+        self.args = args
+        self.output_dim = args.dim * 2
+        
+        self.args.corr_levels = 4
+        self.args.corr_radius = args.radius
+        self.args.corr_channel = args.corr_levels * (args.radius * 2 + 1) ** 2
+        self.cnet = ResNetFPN(args, input_dim=6, output_dim=2 * self.args.dim, norm_layer=nn.BatchNorm2d, init_weight=True)
+
+        # conv for iter 0 results
+        self.init_conv = conv3x3(2 * args.dim, 2 * args.dim)
+        self.upsample_weight = nn.Sequential(
+            # convex combination of 3x3 patches
+            nn.Conv2d(args.dim, args.dim * 2, 3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(args.dim * 2, 64 * 9, 1, padding=0)
+        )
+        self.flow_head = nn.Sequential(
+            # flow(2) + weight(2) + log_b(2)
+            nn.Conv2d(args.dim, 2 * args.dim, 3, padding=1),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(2 * args.dim, 6, 3, padding=1)
+        )
+        if args.iters > 0:
+            self.fnet = ResNetFPN(args, input_dim=3, output_dim=self.output_dim, norm_layer=nn.BatchNorm2d, init_weight=True)
+            self.update_block = BasicUpdateBlock(args, hdim=args.dim, cdim=args.dim)
+    
+    def initialize_flow(self, img):
+        """ Flow is represented as difference between two coordinate grids flow = coords2 - coords1"""
+        N, C, H, W = img.shape
+        coords1 = coords_grid(N, H//8, W//8, device=img.device)
+        coords2 = coords_grid(N, H//8, W//8, device=img.device)
+        return coords1, coords2
+
+    def upsample_data(self, flow, info, mask):
+        """ Upsample [H/8, W/8, C] -> [H, W, C] using convex combination """
+        N, C, H, W = info.shape
+        mask = mask.view(N, 1, 9, 8, 8, H, W)
+        mask = torch.softmax(mask, dim=2)
+
+        up_flow = F.unfold(8 * flow, [3,3], padding=1)
+        up_flow = up_flow.view(N, 2, 9, 1, 1, H, W)
+        up_info = F.unfold(info, [3, 3], padding=1)
+        up_info = up_info.view(N, C, 9, 1, 1, H, W)
+
+        up_flow = torch.sum(mask * up_flow, dim=2)
+        up_flow = up_flow.permute(0, 1, 4, 2, 5, 3)
+        up_info = torch.sum(mask * up_info, dim=2)
+        up_info = up_info.permute(0, 1, 4, 2, 5, 3)
+        
+        return up_flow.reshape(N, 2, 8*H, 8*W), up_info.reshape(N, C, 8*H, 8*W)
+
+    def forward(self, image1, image2, iters=None, flow_gt=None, test_mode=False):
+        """ Estimate optical flow between pair of frames """
+        N, _, H, W = image1.shape
+        if iters is None:
+            iters = self.args.iters
+        if flow_gt is None:
+            flow_gt = torch.zeros(N, 2, H, W, device=image1.device)
+
+        image1 = 2 * (image1 / 255.0) - 1.0
+        image2 = 2 * (image2 / 255.0) - 1.0
+        image1 = image1.contiguous()
+        image2 = image2.contiguous()
+        flow_predictions = []
+        info_predictions = []
+
+        # padding
+        padder = InputPadder(image1.shape)
+        image1, image2 = padder.pad(image1, image2)
+        N, _, H, W = image1.shape
+        dilation = torch.ones(N, 1, H//8, W//8, device=image1.device)
+        # run the context network
+        cnet = self.cnet(torch.cat([image1, image2], dim=1))
+        cnet = self.init_conv(cnet)
+        net, context = torch.split(cnet, [self.args.dim, self.args.dim], dim=1)
+
+        # init flow
+        flow_update = self.flow_head(net)
+        weight_update = .25 * self.upsample_weight(net)
+        flow_8x = flow_update[:, :2]
+        info_8x = flow_update[:, 2:]
+        flow_up, info_up = self.upsample_data(flow_8x, info_8x, weight_update)
+        flow_predictions.append(flow_up)
+        info_predictions.append(info_up)
+            
+        if self.args.iters > 0:
+            # run the feature network
+            fmap1_8x = self.fnet(image1)
+            fmap2_8x = self.fnet(image2)
+            corr_fn = CorrBlock(fmap1_8x, fmap2_8x, self.args)
+
+        for itr in range(iters):
+            N, _, H, W = flow_8x.shape
+            flow_8x = flow_8x.detach()
+            coords2 = (coords_grid(N, H, W, device=image1.device) + flow_8x).detach()
+            corr = corr_fn(coords2, dilation=dilation)
+            net = self.update_block(net, context, corr, flow_8x)
+            flow_update = self.flow_head(net)
+            weight_update = .25 * self.upsample_weight(net)
+            flow_8x = flow_8x + flow_update[:, :2]
+            info_8x = flow_update[:, 2:]
+            # upsample predictions
+            flow_up, info_up = self.upsample_data(flow_8x, info_8x, weight_update)
+            flow_predictions.append(flow_up)
+            info_predictions.append(info_up)
+
+        for i in range(len(info_predictions)):
+            flow_predictions[i] = padder.unpad(flow_predictions[i])
+            info_predictions[i] = padder.unpad(info_predictions[i])
+
+        if test_mode == False:
+            # exlude invalid pixels and extremely large diplacements
+            nf_predictions = []
+            for i in range(len(info_predictions)):
+                if not self.args.use_var:
+                    var_max = var_min = 0
+                else:
+                    var_max = self.args.var_max
+                    var_min = self.args.var_min
+                    
+                raw_b = info_predictions[i][:, 2:]
+                log_b = torch.zeros_like(raw_b)
+                weight = info_predictions[i][:, :2]
+                # Large b Component                
+                log_b[:, 0] = torch.clamp(raw_b[:, 0], min=0, max=var_max)
+                # Small b Component
+                log_b[:, 1] = torch.clamp(raw_b[:, 1], min=var_min, max=0)
+                # term2: [N, 2, m, H, W]
+                term2 = ((flow_gt - flow_predictions[i]).abs().unsqueeze(2)) * (torch.exp(-log_b).unsqueeze(1))
+                # term1: [N, m, H, W]
+                term1 = weight - math.log(2) - log_b
+                nf_loss = torch.logsumexp(weight, dim=1, keepdim=True) - torch.logsumexp(term1.unsqueeze(1) - term2, dim=2)
+                nf_predictions.append(nf_loss)
+
+            return {'final': flow_predictions[-1], 'flow': flow_predictions, 'info': info_predictions, 'nf': nf_predictions}
+        else:
+            return {'final': flow_predictions[-1], 'flow': flow_predictions, 'info': info_predictions, 'nf': None}

--- a/vipe/priors/flow/sea_raft/raft_utils.py
+++ b/vipe/priors/flow/sea_raft/raft_utils.py
@@ -1,0 +1,137 @@
+import torch
+import torch.nn.functional as F
+import numpy as np
+from scipy import interpolate
+
+def load_ckpt(model, path):
+    """ Load checkpoint """
+    state_dict = torch.load(path, map_location=torch.device('cpu'))
+    model.load_state_dict(state_dict, strict=False)
+
+def resize_data(img1, img2, flow, factor=1.0):
+    _, _, h, w = img1.shape
+    h = int(h * factor)
+    w = int(w * factor)
+    img1 = F.interpolate(img1, (h, w), mode='area')
+    img2 = F.interpolate(img2, (h, w), mode='area')
+    flow = F.interpolate(flow, (h, w), mode='area') * factor
+    return img1, img2, flow
+
+class InputPadder:
+    """ Pads images such that dimensions are divisible by 8 """
+    def __init__(self, dims, mode='sintel'):
+        self.ht, self.wd = dims[-2:]
+        pad_ht = (((self.ht // 8) + 1) * 8 - self.ht) % 8
+        pad_wd = (((self.wd // 8) + 1) * 8 - self.wd) % 8
+        if mode == 'sintel':
+            self._pad = [pad_wd//2, pad_wd - pad_wd//2, pad_ht//2, pad_ht - pad_ht//2]
+        else:
+            self._pad = [pad_wd//2, pad_wd - pad_wd//2, 0, pad_ht]
+
+    def pad(self, *inputs):
+        return [F.pad(x, self._pad, mode='replicate') for x in inputs]
+
+    def unpad(self, x):
+        ht, wd = x.shape[-2:]
+        c = [self._pad[2], ht-self._pad[3], self._pad[0], wd-self._pad[1]]
+        return x[..., c[0]:c[1], c[2]:c[3]]
+
+def forward_interpolate(flow):
+    flow = flow.detach().cpu().numpy()
+    dx, dy = flow[0], flow[1]
+
+    ht, wd = dx.shape
+    x0, y0 = np.meshgrid(np.arange(wd), np.arange(ht))
+
+    x1 = x0 + dx
+    y1 = y0 + dy
+    
+    x1 = x1.reshape(-1)
+    y1 = y1.reshape(-1)
+    dx = dx.reshape(-1)
+    dy = dy.reshape(-1)
+
+    valid = (x1 > 0) & (x1 < wd) & (y1 > 0) & (y1 < ht)
+    x1 = x1[valid]
+    y1 = y1[valid]
+    dx = dx[valid]
+    dy = dy[valid]
+
+    flow_x = interpolate.griddata(
+        (x1, y1), dx, (x0, y0), method='nearest', fill_value=0)
+
+    flow_y = interpolate.griddata(
+        (x1, y1), dy, (x0, y0), method='nearest', fill_value=0)
+
+    flow = np.stack([flow_x, flow_y], axis=0)
+    return torch.from_numpy(flow).float()
+
+
+def bilinear_sampler(img, coords, mode='bilinear', mask=False):
+    """ Wrapper for grid_sample, uses pixel coordinates """
+    H, W = img.shape[-2:]
+    xgrid, ygrid = coords.split([1,1], dim=-1)
+    xgrid = 2*xgrid/(W-1) - 1
+    ygrid = 2*ygrid/(H-1) - 1
+
+    grid = torch.cat([xgrid, ygrid], dim=-1)
+    img = F.grid_sample(img, grid, align_corners=True)
+
+    if mask:
+        mask = (xgrid > -1) & (ygrid > -1) & (xgrid < 1) & (ygrid < 1)
+        return img, mask.float()
+
+    return img
+
+def coords_grid(batch, ht, wd, device):
+    coords = torch.meshgrid(torch.arange(ht, device=device), torch.arange(wd, device=device))
+    coords = torch.stack(coords[::-1], dim=0).float()
+    return coords[None].repeat(batch, 1, 1, 1)
+
+
+def upflow8(flow, mode='bilinear'):
+    new_size = (8 * flow.shape[2], 8 * flow.shape[3])
+    return  8 * F.interpolate(flow, size=new_size, mode=mode, align_corners=True)
+
+def transform(T, p):
+    assert T.shape == (4,4)
+    return np.einsum('H W j, i j -> H W i', p, T[:3,:3]) + T[:3, 3]
+
+def from_homog(x):
+    return x[...,:-1] / x[...,[-1]]
+
+def reproject(depth1, pose1, pose2, K1, K2):
+    H, W = depth1.shape
+    x, y = np.meshgrid(np.arange(W), np.arange(H), indexing='xy')
+    img_1_coords = np.stack((x, y, np.ones_like(x)), axis=-1).astype(np.float64)
+    cam1_coords = np.einsum('H W, H W j, i j -> H W i', depth1, img_1_coords, np.linalg.inv(K1))
+    rel_pose = np.linalg.inv(pose2) @ pose1
+    cam2_coords = transform(rel_pose, cam1_coords)
+    return from_homog(np.einsum('H W j, i j -> H W i', cam2_coords, K2))
+
+def induced_flow(depth0, depth1, data):
+    H, W = depth0.shape
+    coords1 = reproject(depth0, data['T0'], data['T1'], data['K0'], data['K1'])
+    x, y = np.meshgrid(np.arange(W), np.arange(H), indexing='xy')
+    coords0 = np.stack([x, y], axis=-1)
+    flow_01 = coords1 - coords0
+
+    H, W = depth1.shape
+    coords1 = reproject(depth1, data['T1'], data['T0'], data['K1'], data['K0'])
+    x, y = np.meshgrid(np.arange(W), np.arange(H), indexing='xy')
+    coords0 = np.stack([x, y], axis=-1)
+    flow_10 = coords1 - coords0
+    
+    return flow_01, flow_10
+
+def check_cycle_consistency(flow_01, flow_10):
+    flow_01 = torch.from_numpy(flow_01).permute(2, 0, 1)[None]
+    flow_10 = torch.from_numpy(flow_10).permute(2, 0, 1)[None]
+    H, W = flow_01.shape[-2:]
+    coords = coords_grid(1, H, W, flow_01.device)
+    coords1 = coords + flow_01
+    flow_reprojected = bilinear_sampler(flow_10, coords1.permute(0, 2, 3, 1))
+    cycle = flow_reprojected + flow_01
+    cycle = torch.norm(cycle, dim=1)
+    mask = (cycle < 0.1 * min(H, W)).float()
+    return mask[0].numpy()

--- a/vipe/priors/flow/sea_raft/spring-M.json
+++ b/vipe/priors/flow/sea_raft/spring-M.json
@@ -1,0 +1,30 @@
+{
+    "name": "spring-M",
+    "dataset": "spring",
+    "gpus": [0, 1, 2, 3, 4, 5, 6, 7],
+
+    "use_var": true,
+    "var_min": 0,
+    "var_max": 10,
+    "pretrain": "resnet34",
+    "initial_dim": 64,
+    "block_dims": [64, 128, 256],
+    "radius": 4,
+    "dim": 128,
+    "num_blocks": 2,
+    "iters": 4,
+
+    "image_size": [540, 960],
+    "scale": -1,
+    "batch_size": 32,
+    "epsilon": 1e-8,
+    "lr": 4e-4,
+    "wdecay": 1e-5,
+    "dropout": 0,
+    "clip": 1.0,
+    "gamma": 0.85,
+    "num_steps": 120000,
+    
+    "restore_ckpt": null,
+    "coarse_config": null
+}

--- a/vipe/priors/flow/sea_raft/update.py
+++ b/vipe/priors/flow/sea_raft/update.py
@@ -1,0 +1,52 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from .layer import ConvNextBlock
+
+class FlowHead(nn.Module):
+    def __init__(self, input_dim=128, hidden_dim=256, output_dim=4):
+        super(FlowHead, self).__init__()
+        self.conv1 = nn.Conv2d(input_dim, hidden_dim, 3, padding=1)
+        self.conv2 = nn.Conv2d(hidden_dim, output_dim, 3, padding=1)
+        self.relu = nn.ReLU(inplace=True)
+
+    def forward(self, x):
+        return self.conv2(self.relu(self.conv1(x)))
+
+class BasicMotionEncoder(nn.Module):
+    def __init__(self, args, dim=128):
+        super(BasicMotionEncoder, self).__init__()
+        cor_planes = args.corr_channel
+        self.convc1 = nn.Conv2d(cor_planes, dim*2, 1, padding=0)
+        self.convc2 = nn.Conv2d(dim*2, dim+dim//2, 3, padding=1)
+        self.convf1 = nn.Conv2d(2, dim, 7, padding=3)
+        self.convf2 = nn.Conv2d(dim, dim//2, 3, padding=1)
+        self.conv = nn.Conv2d(dim*2, dim-2, 3, padding=1)
+
+    def forward(self, flow, corr):
+        cor = F.relu(self.convc1(corr))
+        cor = F.relu(self.convc2(cor))
+        flo = F.relu(self.convf1(flow))
+        flo = F.relu(self.convf2(flo))
+
+        cor_flo = torch.cat([cor, flo], dim=1)
+        out = F.relu(self.conv(cor_flo))
+        return torch.cat([out, flow], dim=1)
+    
+class BasicUpdateBlock(nn.Module):
+    def __init__(self, args, hdim=128, cdim=128):
+        #net: hdim, inp: cdim
+        super(BasicUpdateBlock, self).__init__()
+        self.args = args
+        self.encoder = BasicMotionEncoder(args, dim=cdim)
+        self.refine = []
+        for i in range(args.num_blocks):
+            self.refine.append(ConvNextBlock(2*cdim+hdim, hdim))
+        self.refine = nn.ModuleList(self.refine)
+
+    def forward(self, net, inp, corr, flow, upsample=True):
+        motion_features = self.encoder(flow, corr)
+        inp = torch.cat([inp, motion_features], dim=1)
+        for blk in self.refine:
+            net = blk(torch.cat([net, inp], dim=1))
+        return net

--- a/vipe/priors/flow/sea_raft_model.py
+++ b/vipe/priors/flow/sea_raft_model.py
@@ -1,0 +1,67 @@
+import argparse
+import json
+from pathlib import Path
+
+import torch
+
+from .base import OpticalFlowModel
+from .sea_raft import RAFT
+
+
+_HF_REPO_DEFAULT = "MemorySlices/Tartan-C-T-TSKH-spring540x960-M"
+_CONFIG_PATH = Path(__file__).parent / "sea_raft" / "spring-M.json"
+
+
+def _load_config() -> argparse.Namespace:
+    with open(_CONFIG_PATH) as f:
+        cfg = json.load(f)
+    args = argparse.Namespace()
+    for k, v in cfg.items():
+        setattr(args, k, v)
+    return args
+
+
+class SeaRaftModel(OpticalFlowModel):
+    """SEA-RAFT optical-flow estimator. Loads weights from HuggingFace.
+
+    Args:
+        repo_id: HuggingFace repo id of the pretrained SEA-RAFT model.
+                 Defaults to the spring-M Tartan-C-T-TSKH checkpoint that matches
+                 the bundled `spring-M.json` config.
+        iters: number of refinement iterations at inference.
+        device: torch device. Defaults to current CUDA device.
+    """
+
+    def __init__(
+        self,
+        repo_id: str = _HF_REPO_DEFAULT,
+        iters: int | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(device)
+
+        args = _load_config()
+        if iters is not None:
+            args.iters = iters
+        self.args = args
+
+        self.model = RAFT.from_pretrained(repo_id, args=args)
+        self.model = self.model.to(self.device).eval()
+
+    @torch.no_grad()
+    def estimate(self, image1: torch.Tensor, image2: torch.Tensor) -> torch.Tensor:
+        # SEA-RAFT expects images scaled in [0, 255]: it does (img / 255 * 2 - 1) internally.
+        if image1.dtype != torch.float32:
+            image1 = image1.float()
+            image2 = image2.float()
+        if image1.max() <= 1.0 + 1e-3:
+            image1 = image1 * 255.0
+            image2 = image2 * 255.0
+
+        image1 = image1.to(self.device)
+        image2 = image2.to(self.device)
+
+        out = self.model(image1, image2, iters=self.args.iters, test_mode=True)
+        return out["final"]

--- a/vipe/priors/track_anything/__init__.py
+++ b/vipe/priors/track_anything/__init__.py
@@ -16,7 +16,7 @@ from .seg_tracker import SegTracker
 class TrackAnythingPipeline:
     def __init__(
         self,
-        mask_phrases: list[str],
+        mask_phrases: list[str] | None,
         sam_points_per_side: int = 30,
         sam_run_gap: int = 10,
         model_cache: ModelCache | None = None,
@@ -45,7 +45,8 @@ class TrackAnythingPipeline:
             "reset_image": True,
         }
         self.frame_idx = 0
-        self.caption = "".join([m + "." for m in mask_phrases])
+        self.auto_mode = mask_phrases is None or len(mask_phrases) == 0
+        self.caption = "".join([m + "." for m in (mask_phrases or [])])
         self.sam_run_gap = sam_run_gap
         self.segtracker = SegTracker(
             segtracker_args={
@@ -110,12 +111,24 @@ class TrackAnythingPipeline:
         rgb_frame = frame_data.rgb
 
         if self.frame_idx == 0:
-            pred_mask, _, pred_phrase = self.segtracker.detect_and_seg(rgb_frame, self.caption, **self.threshold_args)
+            if self.auto_mode:
+                pred_mask = self.segtracker.seg_everything(rgb_frame)
+                pred_phrase = {int(i): "object" for i in np.unique(pred_mask) if int(i) != 0}
+            else:
+                pred_mask, _, pred_phrase = self.segtracker.detect_and_seg(
+                    rgb_frame, self.caption, **self.threshold_args
+                )
             self.segtracker.add_reference(rgb_frame, pred_mask)
             self.instance_phrase.update(pred_phrase)
 
         elif self.frame_idx % self.sam_run_gap == 0:
-            seg_mask, _, pred_phrase = self.segtracker.detect_and_seg(rgb_frame, self.caption, **self.threshold_args)
+            if self.auto_mode:
+                seg_mask = self.segtracker.seg_everything(rgb_frame)
+                pred_phrase = {int(i): "object" for i in np.unique(seg_mask) if int(i) != 0}
+            else:
+                seg_mask, _, pred_phrase = self.segtracker.detect_and_seg(
+                    rgb_frame, self.caption, **self.threshold_args
+                )
             track_mask = self.segtracker.track(rgb_frame)
             new_obj_mask, seg_to_new_mapping = self.segtracker.find_new_objs(track_mask, seg_mask)
             if torch.sum(new_obj_mask > 0).item() > rgb_frame.shape[0] * rgb_frame.shape[1] * 0.4:

--- a/vipe/priors/track_anything/groundingdino/models/main/bertwarper.py
+++ b/vipe/priors/track_anything/groundingdino/models/main/bertwarper.py
@@ -13,16 +13,50 @@ from transformers.modeling_outputs import BaseModelOutputWithPoolingAndCrossAtte
 class BertModelWarper(nn.Module):
     def __init__(self, bert_model):
         super().__init__()
-        # self.bert = bert_modelc
-
         self.config = bert_model.config
         self.embeddings = bert_model.embeddings
         self.encoder = bert_model.encoder
         self.pooler = bert_model.pooler
 
-        self.get_extended_attention_mask = bert_model.get_extended_attention_mask
-        self.invert_attention_mask = bert_model.invert_attention_mask
-        self.get_head_mask = bert_model.get_head_mask
+    def _get_dtype(self):
+        return next(self.embeddings.parameters()).dtype
+
+    def get_extended_attention_mask(self, attention_mask, input_shape, device=None, dtype=None):
+        if dtype is None:
+            dtype = self._get_dtype()
+        if attention_mask.dim() == 3:
+            extended_attention_mask = attention_mask[:, None, :, :]
+        elif attention_mask.dim() == 2:
+            extended_attention_mask = attention_mask[:, None, None, :]
+        else:
+            raise ValueError(f"Wrong shape for attention_mask: {attention_mask.shape}")
+        extended_attention_mask = extended_attention_mask.to(dtype=dtype)
+        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
+        return extended_attention_mask
+
+    def invert_attention_mask(self, encoder_attention_mask):
+        dtype = self._get_dtype()
+        if encoder_attention_mask.dim() == 3:
+            encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
+        elif encoder_attention_mask.dim() == 2:
+            encoder_extended_attention_mask = encoder_attention_mask[:, None, None, :]
+        else:
+            raise ValueError(f"Wrong shape for encoder_attention_mask: {encoder_attention_mask.shape}")
+        encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=dtype)
+        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(dtype).min
+        return encoder_extended_attention_mask
+
+    def get_head_mask(self, head_mask, num_hidden_layers, is_attention_chunked=False):
+        if head_mask is None:
+            return [None] * num_hidden_layers
+        if head_mask.dim() == 1:
+            head_mask = head_mask.unsqueeze(0).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+            head_mask = head_mask.expand(num_hidden_layers, -1, -1, -1, -1)
+        elif head_mask.dim() == 2:
+            head_mask = head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1)
+        if is_attention_chunked:
+            head_mask = head_mask.unsqueeze(-1)
+        return head_mask
 
     def forward(
         self,

--- a/vipe/priors/track_anything/seg_tracker.py
+++ b/vipe/priors/track_anything/seg_tracker.py
@@ -124,6 +124,40 @@ class SegTracker:
     def restart_tracker(self):
         self.tracker.restart()
 
+    def seg_everything(self, origin_frame: np.ndarray) -> np.ndarray:
+        """Class-agnostic auto-segmentation of `origin_frame` using SAM's
+        automatic mask generator. Returns a merged-mask numpy array (h, w)
+        where 0 is background and each generated mask gets a unique id.
+
+        Tiny masks (`< self.min_area`) are dropped. Earlier-generated (often
+        higher-quality) masks take precedence on overlap.
+        """
+        bc_id = self.curr_idx
+        bc_mask = self.origin_merged_mask
+
+        masks = self.sam.everything_generator.generate(origin_frame)
+        # Sort by area descending so larger components are written first; subsequent
+        # smaller masks then "carve" finer instances on top.
+        masks.sort(key=lambda m: m["area"], reverse=True)
+
+        H, W = origin_frame.shape[:2]
+        merged = np.zeros((H, W), dtype=np.uint8)
+        if self.origin_merged_mask is None:
+            self.origin_merged_mask = np.zeros((H, W), dtype=np.uint8)
+
+        for m in masks:
+            if m["area"] < self.min_area:
+                continue
+            if self.curr_idx > self.max_obj_num:
+                break
+            seg = m["segmentation"].astype(bool)
+            self.origin_merged_mask = merged.copy()
+            merged = self.add_mask(seg.astype(np.uint8))
+            self.curr_idx += 1
+
+        self.reset_origin_merged_mask(bc_mask, bc_id)
+        return merged
+
     def add_mask(self, interactive_mask: np.ndarray):
         """
         Merge interactive mask with self.origin_merged_mask

--- a/vipe/slam/components/buffer.py
+++ b/vipe/slam/components/buffer.py
@@ -260,6 +260,7 @@ class GraphBuffer:
                 rgb=self.images[frame_idx].moveaxis(1, -1).float(),
                 intrinsics=intrinsics[0],
                 camera_type=self.camera_type,
+                frame_idx=int(self.tstamp[frame_idx].item()),
             )
             disp_sens = unpack_optional(depth_model.estimate(depth_input).metric_depth)
             disp_sens = disp_sens[:, 3::8, 3::8]

--- a/vipe/streams/base.py
+++ b/vipe/streams/base.py
@@ -41,6 +41,8 @@ class FrameAttribute(Enum):
     INSTANCE = "instance"
     MASK = "mask"
     METRIC_DEPTH = "metric_depth"
+    OPTICAL_FLOW = "optical_flow"
+    FLOW_CONSISTENCY = "flow_consistency"
 
 
 @dataclass(kw_only=True, slots=True)
@@ -58,6 +60,10 @@ class VideoFrame:
     - instance_phrases: A dictionary of instance id to phrase mapping.
     - mask: Binary mask of the frame. The shape is (H, W), with 0 for invalid pixels.
     - metric_depth: The depth map of the frame. The shape is (H, W). Value is in metric scale.
+    - optical_flow: Forward/backward optical flow. The shape is (H, W, 4), with
+      channels [fwd_dx, fwd_dy, bwd_dx, bwd_dy] in pixels.
+    - flow_consistency: Forward/backward optical-flow consistency masks. The
+      shape is (H, W, 2), with channels [fwd_mask, bwd_mask].
     - information: Additional information about the frame
     """
 
@@ -72,6 +78,8 @@ class VideoFrame:
     instance_phrases: dict[int, str] | None = None
     mask: torch.Tensor | None = None
     metric_depth: torch.Tensor | None = None
+    optical_flow: torch.Tensor | None = None
+    flow_consistency: torch.Tensor | None = None
     information: str = ""
 
     def size(self) -> tuple[int, int]:
@@ -95,6 +103,10 @@ class VideoFrame:
             attributes.add(FrameAttribute.MASK)
         if self.metric_depth is not None:
             attributes.add(FrameAttribute.METRIC_DEPTH)
+        if self.optical_flow is not None:
+            attributes.add(FrameAttribute.OPTICAL_FLOW)
+        if self.flow_consistency is not None:
+            attributes.add(FrameAttribute.FLOW_CONSISTENCY)
 
         return attributes
 
@@ -111,6 +123,10 @@ class VideoFrame:
             return self.mask
         if attribute == FrameAttribute.METRIC_DEPTH:
             return self.metric_depth
+        if attribute == FrameAttribute.OPTICAL_FLOW:
+            return self.optical_flow
+        if attribute == FrameAttribute.FLOW_CONSISTENCY:
+            return self.flow_consistency
         raise ValueError(f"Attribute {attribute} is not available in the frame.")
 
     def set_attribute(self, attribute: FrameAttribute, value: Any) -> None:
@@ -126,6 +142,10 @@ class VideoFrame:
             self.mask = value
         elif attribute == FrameAttribute.METRIC_DEPTH:
             self.metric_depth = value
+        elif attribute == FrameAttribute.OPTICAL_FLOW:
+            self.optical_flow = value
+        elif attribute == FrameAttribute.FLOW_CONSISTENCY:
+            self.flow_consistency = value
         else:
             raise ValueError(f"Attribute {attribute} is not available in the frame.")
 
@@ -140,6 +160,8 @@ class VideoFrame:
             instance=map_cpu(self.instance),
             instance_phrases=self.instance_phrases,
             metric_depth=map_cpu(self.metric_depth),
+            optical_flow=map_cpu(self.optical_flow),
+            flow_consistency=map_cpu(self.flow_consistency),
             pose=map_cpu(self.pose),
             intrinsics=map_cpu(self.intrinsics),
             camera_type=self.camera_type,
@@ -157,6 +179,8 @@ class VideoFrame:
             instance=map_cuda(self.instance),
             instance_phrases=self.instance_phrases,
             metric_depth=map_cuda(self.metric_depth),
+            optical_flow=map_cuda(self.optical_flow),
+            flow_consistency=map_cuda(self.flow_consistency),
             pose=map_cuda(self.pose),
             intrinsics=map_cuda(self.intrinsics),
             camera_type=self.camera_type,
@@ -192,6 +216,34 @@ class VideoFrame:
                 0, 0
             ]
 
+        new_optical_flow = None
+        if self.optical_flow is not None:
+            new_optical_flow = (
+                torch.nn.functional.interpolate(
+                    self.optical_flow.permute(2, 0, 1)[None],
+                    size,
+                    mode="bilinear",
+                    align_corners=False,
+                )
+                .squeeze(0)
+                .permute(1, 2, 0)
+            )
+            new_optical_flow[..., [0, 2]] *= w1 / w0
+            new_optical_flow[..., [1, 3]] *= h1 / h0
+
+        new_flow_consistency = None
+        if self.flow_consistency is not None:
+            new_flow_consistency = (
+                torch.nn.functional.interpolate(
+                    self.flow_consistency.permute(2, 0, 1)[None].float(),
+                    size,
+                    mode="nearest",
+                )
+                .squeeze(0)
+                .permute(1, 2, 0)
+                .bool()
+            )
+
         new_intrinsics = None
         if self.intrinsics is not None:
             new_intrinsics = self.intrinsics.clone()
@@ -207,6 +259,8 @@ class VideoFrame:
             instance=new_instance,
             instance_phrases=self.instance_phrases,
             metric_depth=new_metric_depth,
+            optical_flow=new_optical_flow,
+            flow_consistency=new_flow_consistency,
             pose=self.pose,
             intrinsics=new_intrinsics,
             camera_type=new_camera_type,
@@ -234,6 +288,14 @@ class VideoFrame:
         if self.metric_depth is not None:
             new_metric_depth = self.metric_depth[top:bottom, left:right]
 
+        new_optical_flow = None
+        if self.optical_flow is not None:
+            new_optical_flow = self.optical_flow[top:bottom, left:right]
+
+        new_flow_consistency = None
+        if self.flow_consistency is not None:
+            new_flow_consistency = self.flow_consistency[top:bottom, left:right]
+
         new_intrinsics = None
         if self.intrinsics is not None:
             new_intrinsics = self.intrinsics.clone()
@@ -249,6 +311,8 @@ class VideoFrame:
             instance=new_instance,
             instance_phrases=self.instance_phrases,
             metric_depth=new_metric_depth,
+            optical_flow=new_optical_flow,
+            flow_consistency=new_flow_consistency,
             pose=self.pose,
             intrinsics=new_intrinsics,
             camera_type=new_camera_type,

--- a/vipe/utils/io.py
+++ b/vipe/utils/io.py
@@ -66,8 +66,16 @@ class ArtifactPath:
         return self.base_path / "flow" / f"{self.artifact_name}.zip"
 
     @property
+    def flow_consistency_path(self) -> Path:
+        return self.base_path / "flow_consistency" / f"{self.artifact_name}.zip"
+
+    @property
     def mask_path(self) -> Path:
         return self.base_path / "mask" / f"{self.artifact_name}.zip"
+
+    @property
+    def static_mask_path(self) -> Path:
+        return self.base_path / "static_mask" / f"{self.artifact_name}.zip"
 
     @property
     def mask_phrase_path(self) -> Path:
@@ -104,7 +112,9 @@ class ArtifactPath:
             self.depth_path,
             self.intrinsics_path,
             self.flow_path,
+            self.flow_consistency_path,
             self.mask_path,
+            self.static_mask_path,
             self.mask_phrase_path,
             self.meta_info_path,
             self.meta_vis_path,
@@ -338,6 +348,112 @@ def read_instance_phrases(instance_phrase_path: Path) -> dict[int, str]:
     return instance_phrases
 
 
+def save_static_mask_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream) -> None:
+    # Save binary static-valid masks as zipped PNG files.
+    mask_list = [
+        (frame_idx, mask_data.cpu().numpy())
+        for frame_idx, mask_data in enumerate(cached_final_stream.get_stream_attribute(FrameAttribute.MASK))
+        if mask_data is not None
+    ]
+    if len(mask_list) > 0:
+        out_path.static_mask_path.parent.mkdir(exist_ok=True, parents=True)
+        with zipfile.ZipFile(out_path.static_mask_path, "w", zipfile.ZIP_DEFLATED) as z:
+            for frame_idx, mask in mask_list:
+                mask_png = (mask.astype(bool).astype(np.uint8) * 255)
+                _, mask_buffer = cv2.imencode(".png", mask_png)
+                z.writestr(f"{frame_idx:05d}.png", mask_buffer.tobytes())
+
+
+def read_static_mask_artifacts(zip_file_path: Path) -> Iterator[tuple[int, torch.Tensor]]:
+    """
+    Read static-valid binary masks from zipped PNG files.
+    """
+    with zipfile.ZipFile(zip_file_path, "r") as z:
+        for file_name in sorted(z.namelist()):
+            frame_idx = int(file_name.split(".")[0])
+            with z.open(file_name) as f:
+                mask_buffer = np.frombuffer(f.read(), dtype=np.uint8)
+                mask = cv2.imdecode(mask_buffer, cv2.IMREAD_UNCHANGED)
+                assert mask is not None, f"Failed to decode static mask {file_name}"
+                yield frame_idx, torch.from_numpy(mask.copy() > 0)
+
+
+def save_flow_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream) -> None:
+    # Save optical flow as zipped 16-bit PNG files.
+    flow_list = [
+        (frame_idx, flow_data.cpu().numpy())
+        for frame_idx, flow_data in enumerate(cached_final_stream.get_stream_attribute(FrameAttribute.OPTICAL_FLOW))
+        if flow_data is not None
+    ]
+    if len(flow_list) > 0:
+        out_path.flow_path.parent.mkdir(exist_ok=True, parents=True)
+        with zipfile.ZipFile(out_path.flow_path, "w", zipfile.ZIP_DEFLATED) as z:
+            for frame_idx, flow in flow_list:
+                height, width, channels = flow.shape
+                assert channels == 4, f"Expected optical flow shape (H, W, 4), got {flow.shape}"
+                flow = flow.copy()
+                flow[..., [0, 2]] = flow[..., [0, 2]] / max(width - 1, 1)
+                flow[..., [1, 3]] = flow[..., [1, 3]] / max(height - 1, 1)
+                flow = (flow + 1) * 0.5 * 65535
+                flow = flow.astype(np.uint16)
+                with tempfile.NamedTemporaryFile(suffix=".png") as f:
+                    cv2.imwrite(f.name, flow)
+                    z.write(f.name, f"{frame_idx:05d}.png")
+
+
+def read_flow_artifacts(zip_file_path: Path) -> Iterator[tuple[int, torch.Tensor]]:
+    """
+    Read optical flow from zipped 16-bit PNG files.
+    """
+    with zipfile.ZipFile(zip_file_path, "r") as z:
+        for file_name in sorted(z.namelist()):
+            if not file_name.endswith(".png"):
+                continue
+            frame_idx = int(file_name.split(".")[0])
+            with z.open(file_name) as f:
+                flow_buffer = np.frombuffer(f.read(), dtype=np.uint8)
+                flow = cv2.imdecode(flow_buffer, cv2.IMREAD_UNCHANGED)
+                assert flow is not None, f"Failed to decode optical flow {file_name}"
+                yield frame_idx, torch.from_numpy(flow.copy())
+
+
+def save_flow_consistency_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream) -> None:
+    # Save forward/backward optical-flow consistency masks as zipped PNG files.
+    mask_list = [
+        (frame_idx, mask_data.cpu().numpy())
+        for frame_idx, mask_data in enumerate(
+            cached_final_stream.get_stream_attribute(FrameAttribute.FLOW_CONSISTENCY)
+        )
+        if mask_data is not None
+    ]
+    if len(mask_list) > 0:
+        out_path.flow_consistency_path.parent.mkdir(exist_ok=True, parents=True)
+        with zipfile.ZipFile(out_path.flow_consistency_path, "w", zipfile.ZIP_DEFLATED) as z:
+            for frame_idx, consistency in mask_list:
+                height, width, channels = consistency.shape
+                assert channels == 2, f"Expected flow consistency shape (H, W, 2), got {consistency.shape}"
+                del height, width
+                for suffix, mask in (("fwd", consistency[..., 0]), ("bwd", consistency[..., 1])):
+                    mask_png = (mask.astype(bool).astype(np.uint8) * 255)
+                    _, mask_buffer = cv2.imencode(".png", mask_png)
+                    z.writestr(f"{frame_idx:05d}_{suffix}.png", mask_buffer.tobytes())
+
+
+def read_flow_consistency_artifacts(zip_file_path: Path) -> Iterator[tuple[int, str, torch.Tensor]]:
+    """
+    Read forward/backward optical-flow consistency masks from zipped PNG files.
+    """
+    with zipfile.ZipFile(zip_file_path, "r") as z:
+        for file_name in sorted(z.namelist()):
+            frame_idx = int(file_name.split("_")[0])
+            direction = file_name.split("_")[1].split(".")[0]
+            with z.open(file_name) as f:
+                mask_buffer = np.frombuffer(f.read(), dtype=np.uint8)
+                mask = cv2.imdecode(mask_buffer, cv2.IMREAD_UNCHANGED)
+                assert mask is not None, f"Failed to decode flow consistency mask {file_name}"
+                yield frame_idx, direction, torch.from_numpy(mask.copy() > 0)
+
+
 def save_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream) -> None:
     """
     Save each attribute independently.
@@ -354,6 +470,15 @@ def save_artifacts(out_path: ArtifactPath, cached_final_stream: VideoStream) -> 
 
     # Save metric depth as zipped exr files.
     save_depth_artifacts(out_path, cached_final_stream)
+
+    # Save static-valid binary masks as zipped PNG files.
+    save_static_mask_artifacts(out_path, cached_final_stream)
+
+    # Save optical flow as zipped 16-bit PNG files.
+    save_flow_artifacts(out_path, cached_final_stream)
+
+    # Save optical-flow consistency masks as zipped PNG files.
+    save_flow_consistency_artifacts(out_path, cached_final_stream)
 
     # Save Instance mask as zipped PNG files.
     instance_list = [

--- a/vipe/utils/visualization.py
+++ b/vipe/utils/visualization.py
@@ -446,6 +446,17 @@ def save_projection_video(
             instance_img = cv2.resize(instance_img, (img_w, img_h))
             yield cv2.addWeighted(rgb_img, 0.5, instance_img, 0.5, 0)
 
+    def get_mask_imgs():
+        for frame_data, rgb_img in zip(video_stream, get_rgb_imgs()):
+            assert isinstance(frame_data, VideoFrame)
+            if frame_data.mask is None:
+                yield na_img
+                continue
+            mask_img = frame_data.mask.cpu().numpy().astype(np.uint8)
+            mask_img = colorize_mask(mask_img)
+            mask_img = cv2.resize(mask_img, (img_w, img_h))
+            yield cv2.addWeighted(rgb_img, 0.5, mask_img, 0.5, 0)
+
     def get_empty_imgs():
         for _ in range(len(video_stream)):
             yield na_img
@@ -457,6 +468,7 @@ def save_projection_video(
                 "depth": get_depth_imgs(),
                 "pcd": get_pcd_imgs(),
                 "instance": get_instance_imgs(),
+                "mask": get_mask_imgs(),
                 "rectified": get_rectified_imgs(),
                 "empty": get_empty_imgs(),
             }[t]

--- a/vipe/utils/visualization.py
+++ b/vipe/utils/visualization.py
@@ -129,6 +129,13 @@ def colorize_depth(
     return depth
 
 
+def pad_image_width(img: np.ndarray, target_width: int, fill_value: int = 0) -> np.ndarray:
+    if img.shape[1] >= target_width:
+        return img
+    pad_width = target_width - img.shape[1]
+    return np.pad(img, ((0, 0), (0, pad_width), (0, 0)), mode="constant", constant_values=fill_value)
+
+
 def draw_points_batch(
     canvas: np.ndarray,
     pts: np.ndarray,
@@ -486,6 +493,8 @@ def save_projection_video(
                 for img in img_iterator:
                     img_row.append(next(img))
                 img_rows.append(np.concatenate(img_row, axis=1))
+            max_row_width = max(img_row.shape[1] for img_row in img_rows)
+            img_rows = [pad_image_width(img_row, max_row_width) for img_row in img_rows]
             img_final = np.concatenate(img_rows, axis=0)
             text_desc = f"Frame {frame_idx:03d}"
             # text_desc += f" | BA {slam_output.ba_residual:.4f}"


### PR DESCRIPTION
## Summary

This PR integrates the best contributions from four community forks into a single branch:

- **Fast pose-only pipeline** (`pose_only.yaml`) â€” new `PoseOnlyAnnotationPipeline` that skips dense depth post-processing, ~4Ã— faster for pose-only use cases; exposes `track_downscale` and `track_stride` on `InstanceInitConfig` to reduce tracking resolution and frequency in all pipelines.
- **CachedDepthModel + Pi3XMoGe2 backend** â€” reads precomputed depth from `.npz` files via env var (useful for batch / SANA-WM workflows); adds a Pi3X + MoGe-2 fused depth backend with EMA scale fusion (App. B.1). Also fixes `BertModelWarper` compatibility with **transformers 5.x**.
- **Motion-aware dynamic masks** â€” new `motion` mode in `InstanceInitConfig` that replaces text-prompted segmentation with automatic dynamic-object detection via bidirectional SEA-RAFT optical flow, forward-backward consistency, and Sampson epipolar error scoring. Adds `vipe/priors/dynamic_mask/` and `vipe/priors/flow/sea_raft/` (BSD 3-Clause).
- **TSDF point cloud integration** â€” voxel-aligned TSDF init for cleaner point clouds; dynamic-object masking before integration; depth edge pruning; Statistical Outlier Removal; automatic IQR-based depth truncation for indoor/outdoor generalization. All parameters exposed in config. Includes `scripts/tsdf_ablation.py`.
- **GEN3C export utility** â€” `convert_vipe_to_gen3c.py` converts VIPE output (depth EXR in ZIP, poses, intrinsics) to GEN3C input format with frame padding and sparse camera interpolation.

## Sources

| Improvement | Fork |
|---|---|
| Pose-only pipeline + track downscale/stride | [ashawkey @ nv-tlabs/vipe](https://github.com/nv-tlabs/vipe/commit/43fa1effc9baf329c5b365bcf06ddb2ef6627662) |
| CachedDepth + Pi3XMoGe2 + BertWarper fix | [WANGXutao98/vipe](https://github.com/WANGXutao98/vipe) |
| Dynamic mask via optical flow | [ladvu/vipe](https://github.com/ladvu/vipe) |
| TSDF integration | [nbardy/vipe](https://github.com/nbardy/vipe) |
| GEN3C conversion script | [SaferDrive-AI/vipe](https://github.com/SaferDrive-AI/vipe) |

## Reviewer notes

- One merge conflict was resolved in `vipe/pipeline/default.py` and `vipe/config/pipeline.py`: the `track_downscale`/`track_stride` fields (pose-only commit) were combined with the `sam_points_per_side`/`flow_alpha`/`flow_beta` fields (dynamic mask commit) â€” both sets of fields are preserved.
- `PoseOnlyAnnotationPipeline` and `Pi3XMoGe2DepthModel` are intentionally **not** combined: pose-only skips the post-processing pass where Pi3X+MoGe2 runs. Use the `default` pipeline with `depth_align_model: pi3x_moge2` to get fused depth.
- SEA-RAFT is vendored under `vipe/priors/flow/sea_raft/` (BSD 3-Clause, Princeton Vision & Learning Lab).
