### PR TITLE
Port cuvslam implementation to the latest PyCuVSLAM API

### DIFF
--- a/vipe/slam/components/sparse_tracks/cuvslam.py
+++ b/vipe/slam/components/sparse_tracks/cuvslam.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import cuvslam as vslam
 import numpy as np
 import torch
-import vslam
 
 from vipe.streams.base import VideoFrame
 from vipe.utils.misc import unpack_optional
@@ -43,7 +43,7 @@ class CuVSLAMSparseTracks(SparseTracks):
 
             cam = vslam.Camera()
             cam.distortion = vslam.Distortion()
-            cam.distortion.model = vslam.DistortionModel.Pinhole
+            cam.distortion.model = vslam.Distortion.Model.Pinhole
             cam.focal = [float(fx), float(fy)]
             cam.principal = [float(cx), float(cy)]
             cam.size = [int(frame_width), int(frame_height)]
@@ -56,8 +56,8 @@ class CuVSLAMSparseTracks(SparseTracks):
         rig.cameras = vslam_cameras
         rig.imus = []
 
-        cfg = vslam.TrackerConfig()
-        cfg.odometry_mode = vslam.TrackerOdometryMode.Mono
+        cfg = vslam.Tracker.OdometryConfig()
+        cfg.odometry_mode = vslam.Tracker.OdometryMode.Mono
         cfg.enable_observations_export = True
         tracker = vslam.Tracker(rig, cfg)
 

--- a/vipe/slam/components/sparse_tracks/cuvslam.py
+++ b/vipe/slam/components/sparse_tracks/cuvslam.py
@@ -28,15 +28,15 @@ class CuVSLAMSparseTracks(SparseTracks):
 
     def __init__(self, n_views: int) -> None:
         super().__init__(n_views)
-        self.tracker = None
-        self.frame_idx = 0
+        self.tracker: cuvslam.Tracker | None = None
+        self.frame_idx: int = 0
 
     def _build_tracker(self, frame_data_list: list[VideoFrame]) -> None:
         assert len(frame_data_list) == 1, (
             "Only single-camera supported for now. Mainly due to rig transformations not properly set."
         )
 
-        vslam_cameras = []
+        vslam_cameras: list[cuvslam.Camera] = []
         for frame_data in frame_data_list:
             frame_height, frame_width = frame_data.size()
             fx, fy, cx, cy = unpack_optional(frame_data.intrinsics)

--- a/vipe/slam/components/sparse_tracks/cuvslam.py
+++ b/vipe/slam/components/sparse_tracks/cuvslam.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import cuvslam as vslam
+import cuvslam
 import numpy as np
 import torch
 
@@ -41,25 +41,25 @@ class CuVSLAMSparseTracks(SparseTracks):
             frame_height, frame_width = frame_data.size()
             fx, fy, cx, cy = unpack_optional(frame_data.intrinsics)
 
-            cam = vslam.Camera()
-            cam.distortion = vslam.Distortion()
-            cam.distortion.model = vslam.Distortion.Model.Pinhole
+            cam = cuvslam.Camera()
+            cam.distortion = cuvslam.Distortion()
+            cam.distortion.model = cuvslam.Distortion.Model.Pinhole
             cam.focal = [float(fx), float(fy)]
             cam.principal = [float(cx), float(cy)]
             cam.size = [int(frame_width), int(frame_height)]
-            cam.rig_from_camera = vslam.Pose()
+            cam.rig_from_camera = cuvslam.Pose()
             cam.rig_from_camera.rotation = np.array([0, 0, 0, 1])
             cam.rig_from_camera.translation = np.array([0, 0, 0])
             vslam_cameras.append(cam)
 
-        rig = vslam.Rig()
+        rig = cuvslam.Rig()
         rig.cameras = vslam_cameras
         rig.imus = []
 
-        cfg = vslam.Tracker.OdometryConfig()
-        cfg.odometry_mode = vslam.Tracker.OdometryMode.Mono
+        cfg = cuvslam.Tracker.OdometryConfig()
+        cfg.odometry_mode = cuvslam.Tracker.OdometryMode.Mono
         cfg.enable_observations_export = True
-        tracker = vslam.Tracker(rig, cfg)
+        tracker = cuvslam.Tracker(rig, cfg)
 
         self.tracker = tracker
         self.frame_idx = 0


### PR DESCRIPTION
I wanted to test the sparse tracking implementation, so I made an attempt to update cuvslam.py to work with the latest [PyCuVSLAM](https://github.com/nvidia-isaac/cuVSLAM#install-pycuvslam) releases. I'm not sure if it's working correctly, but with these changes, it's able to execute, and I can see sane-looking tracking results logged into rerun recordings.