### PR TITLE
Fix pose/depth initialization in the frontend

### DIFF
--- a/vipe/slam/components/frontend.py
+++ b/vipe/slam/components/frontend.py
@@ -18,6 +18,8 @@
 # Licensed under the MIT License. See THIRD_PARTY_LICENSES.md for details.
 # -------------------------------------------------------------------------------------------------
 
+from enum import Enum, auto, unique
+
 import torch
 from omegaconf import DictConfig
 
@@ -26,6 +28,12 @@ from vipe.ext.lietorch import SE3
 from ..networks.droid_net import DroidNet
 from .buffer import GraphBuffer
 from .factor_graph import FactorGraph
+
+
+@unique
+class InitState(Enum):
+    Uninitialized = auto()
+    Initialized = auto()
 
 
 class SLAMFrontend:
@@ -49,7 +57,7 @@ class SLAMFrontend:
         self.t1 = 0
 
         # frontend variables
-        self.is_initialized = False
+        self.init_state = InitState.Uninitialized
 
         self.max_age = 25
         self.iters1 = 4
@@ -143,16 +151,17 @@ class SLAMFrontend:
         self.video.dirty[: self.t1] = True
 
         # initialization complete
-        self.is_initialized = True
+        self.init_state = InitState.Initialized
+
         self.graph.rm_factors(self.graph.ii < self.warmup - 4, store=True)
 
     def run(self):
         """main update"""
 
         # do initialization
-        if not self.is_initialized and self.video.n_frames == self.warmup:
+        if self.init_state is InitState.Uninitialized and self.video.n_frames == self.warmup:
             self.__initialize()
 
         # do update if new keyframe is added.
-        elif self.is_initialized and self.t1 < self.video.n_frames:
+        elif self.init_state is not InitState.Uninitialized and self.t1 < self.video.n_frames:
             self.__update()

--- a/vipe/slam/components/frontend.py
+++ b/vipe/slam/components/frontend.py
@@ -34,6 +34,7 @@ from .factor_graph import FactorGraph
 class InitState(Enum):
     Uninitialized = auto()
     Initialized = auto()
+    Updated = auto()
 
 
 class SLAMFrontend:
@@ -85,6 +86,18 @@ class SLAMFrontend:
     def __update(self):
         """add edges, perform update"""
 
+        if not self.has_init_pose:
+            self.__init_pose()
+
+        assert self.init_state is not InitState.Uninitialized
+        if self.init_state is InitState.Initialized:
+            for v in range(self.video.n_views):
+                self.video.disps[self.t1, v] = self.video.disps[self.t1 - 4 : self.t1, v].mean()
+        elif self.init_state is InitState.Updated:
+            for v in range(self.video.n_views):
+                self.video.disps[self.t1, v] = self.video.disps[self.t1 - 1, v].mean()
+        self.init_state = InitState.Updated
+
         self.t1 += 1
 
         # t1 - 1 is the new-added frame
@@ -121,12 +134,6 @@ class SLAMFrontend:
             for _ in range(self.iters2):
                 self.graph.update(use_inactive=True, fixed_motion=self.has_init_pose)
 
-        # set pose for next itration
-        if not self.has_init_pose:
-            self.__init_pose()
-        for v in range(self.video.n_views):
-            self.video.disps[self.t1, v] = self.video.disps[self.t1 - 1, v].mean()
-
         # update visualization
         self.video.dirty[self.graph.ii.min() : self.t1] = True
 
@@ -144,10 +151,6 @@ class SLAMFrontend:
             for _ in range(8):
                 self.graph.update(t0=1, use_inactive=True, fixed_motion=self.has_init_pose)
 
-        if not self.has_init_pose:
-            self.__init_pose()
-        for v in range(self.video.n_views):
-            self.video.disps[self.t1, v] = self.video.disps[self.t1 - 4 : self.t1, v].mean()
         self.video.dirty[: self.t1] = True
 
         # initialization complete


### PR DESCRIPTION
Previously, the two functions called by `SLAMFrontend.run` (`__initialize` and `__update`) were setting an initial guess for the next keyframe's pose and depth at the end of the previous iteration. When bundle adjustment was run (according to the `frontend_backend_iters` field in [`SLAMConfig`](https://nv-tlabs.github.io/vipe/reference/configuration/#slamconfig)), it would invalidate these initial guesses, but they would be used anyway for the next keyframe.

In the case of the dataset I'm experimenting with, this would lead to a failure in tracking, which later runs of the backend would usually fail to recover from.

This pull request moves the pose and depth initialization to the top of `SLAMFrontend.__update`, so that in iterations where the backend has been run, it uses the updated pose and depth values.